### PR TITLE
x64 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.4.2.{build}
+version: 1.12.2.{build}
 image: Visual Studio 2015
 
 
@@ -26,7 +26,7 @@ build:
 
 build_script:
     - cd "%APPVEYOR_BUILD_FOLDER%"/vs.proj
-    - msbuild NppPluginNavigateTo.vcxproj /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%"
+    - msbuild NppPluginNavigateTo.vcxproj /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 after_build:
     - cd "%APPVEYOR_BUILD_FOLDER%"

--- a/src/DockingFeature/NavigateTo.rc
+++ b/src/DockingFeature/NavigateTo.rc
@@ -62,12 +62,12 @@ BEGIN
             VALUE "Comments", "Latest Source available from https://github.com/young-developer/nppNavigateTo"
             VALUE "CompanyName", "Oleksii Maryshchenko"
             VALUE "FileDescription", "Notepad++ File NavigateTO : a free (GPL) source code file NavigateTo"
-            VALUE "FileVersion", "1, 10, 2, 0"
+            VALUE "FileVersion", "1, 12, 2, 0"
             VALUE "InternalName", "NavigateTo"
             VALUE "LegalCopyright", "Copyright (C) 2017 Oleksii Maryshchenko"
             VALUE "OriginalFilename", "NavigateTo.dll"
             VALUE "ProductName", "NavigateTo plugin"
-            VALUE "ProductVersion", "1, 10, 2, 0"
+            VALUE "ProductVersion", "1, 12, 2, 0"
             VALUE "SpecialBuild", "UNICODE"
         END
     END

--- a/src/DockingFeature/NavigateToDlg.cpp
+++ b/src/DockingFeature/NavigateToDlg.cpp
@@ -417,13 +417,13 @@ INT_PTR CALLBACK NavigateToDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
                 //  Get the edit window handle to each combo box. 
                 HWND hwndEdit = GetWindow(hwndGoLineEdit, GW_CHILD);
                 Edit_SetCueBannerTextFocused(hwndEdit,TEXT(" Filter by Name, Path. Put a | at the beginning of the line to invert the whole filter condition"), true);
-                g_oldComboProc = (WNDPROC) SetWindowLongPtr(hwndEdit, GWLP_WNDPROC, (DWORD) ComboProc);
-                g_oldComboBoxProc = (WNDPROC) SetWindowLongPtr(hwndEdit, GWLP_WNDPROC, (DWORD) ComboBoxProc);
+                g_oldComboProc = (WNDPROC) SetWindowLongPtr(hwndEdit, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(ComboProc));
+                g_oldComboBoxProc = (WNDPROC) SetWindowLongPtr(hwndEdit, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(ComboBoxProc));
 			}
             
             if(NULL != hwndListView)
             {
-                g_oldListProc = (WNDPROC) ::SetWindowLongPtr(hwndListView, GWLP_WNDPROC, (DWORD) listProc);
+                g_oldListProc = (WNDPROC) ::SetWindowLongPtr(hwndListView, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(listProc));
             }
 
             _winMgr.CalcLayout(_hSelf);
@@ -535,7 +535,7 @@ INT_PTR CALLBACK NavigateToDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
                 if(((LPNMHDR)lParam)->code == NM_CUSTOMDRAW)
                 {
                     SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, 
-                        (LONG)ProcessCustomDraw(lParam));
+                        static_cast<LONG_PTR>(ProcessCustomDraw(lParam)));
                    return TRUE;
                 }
             }

--- a/src/DockingFeature/NavigateToDlg.h
+++ b/src/DockingFeature/NavigateToDlg.h
@@ -29,6 +29,7 @@
 #include <forward_list>
 #include <unordered_map>
 #include <Windowsx.h>
+#include <CommCtrl.h>
 
 class NavigateToDlg : public SizeableDlg
 {

--- a/src/DockingFeature/StaticDialog.h
+++ b/src/DockingFeature/StaticDialog.h
@@ -29,7 +29,7 @@ public :
 	StaticDialog() : Window() {};
 	~StaticDialog(){
 		if (isCreated()) {
-			::SetWindowLongPtr(_hSelf, GWLP_USERDATA, (long)NULL);	//Prevent run_dlgProc from doing anything, since its virtual
+			::SetWindowLongPtr(_hSelf, GWLP_USERDATA, static_cast<LONG_PTR>(NULL));	//Prevent run_dlgProc from doing anything, since its virtual
 			destroy();
 		}
 	};

--- a/src/DockingFeature/resource.h
+++ b/src/DockingFeature/resource.h
@@ -37,8 +37,6 @@
 #define _USE_ATTRIBUTES_FOR_SAL         0
 #define __drv_typeConst                 0
 #define WINAPI_PARTITION_DESKTOP        0x00000001
-#define CREATEPROCESS_MANIFEST_RESOURCE_ID 1
-#define MINIMUM_RESERVED_MANIFEST_RESOURCE_ID 1
 #define SW_SHOWNORMAL                   1
 #define SW_NORMAL                       1
 #define SHOW_OPENWINDOW                 1
@@ -221,7 +219,6 @@
 #define VFF_CURNEDEST                   0x0001
 #define VIFF_FORCEINSTALL               0x0001
 #define WINAPI_PARTITION_APP            0x00000002
-#define ISOLATIONAWARE_MANIFEST_RESOURCE_ID 2
 #define SW_SHOWMINIMIZED                2
 #define SHOW_ICONWINDOW                 2
 #define SW_OTHERZOOM                    2
@@ -309,7 +306,6 @@
 #define __drv_typeBitset                2
 #define VFF_FILEINUSE                   0x0002
 #define VIFF_DONTDELETEOLD              0x0002
-#define ISOLATIONAWARE_NOSTATICIMPORT_MANIFEST_RESOURCE_ID 3
 #define SW_SHOWMAXIMIZED                3
 #define SW_MAXIMIZE                     3
 #define SHOW_FULLSCREEN                 3
@@ -535,7 +531,6 @@
 #define LANG_ICELANDIC                  0x0f
 #define SUBLANG_ARABIC_BAHRAIN          0x0f
 #define SUBLANG_SPANISH_PARAGUAY        0x0f
-#define MAXIMUM_RESERVED_MANIFEST_RESOURCE_ID 16
 #define VK_SHIFT                        0x10
 #define WM_CLOSE                        0x0010
 #define HTBOTTOMLEFT                    16
@@ -598,7 +593,6 @@
 #define LANG_PORTUGUESE                 0x16
 #define VK_JUNJA                        0x17
 #define LANG_ROMANSH                    0x17
-#define RT_MANIFEST                     24
 #define VK_FINAL                        0x18
 #define WM_SHOWWINDOW                   0x0018
 #define LANG_ROMANIAN                   0x18
@@ -1390,7 +1384,6 @@
 #define MULTIFILEOPENORD                1537
 #define _WIN32_WINNT_WIN8               0x0602
 #define _WIN32_IE_WS03                  0x0602
-#define _WIN32_WINNT                    0x0602
 #define PRINTDLGORD                     1538
 #define _WIN32_IE_IE60SP2               0x0603
 #define PRNSETUPDLGORD                  1539
@@ -1463,23 +1456,16 @@
 #define IDTIMEOUT                       32000
 #define OCR_NORMAL                      32512
 #define OIC_SAMPLE                      32512
-#define IDI_APPLICATION                 32512
 #define OCR_IBEAM                       32513
 #define OIC_HAND                        32513
-#define IDI_HAND                        32513
 #define OCR_WAIT                        32514
 #define OIC_QUES                        32514
-#define IDI_QUESTION                    32514
 #define OCR_CROSS                       32515
 #define OIC_BANG                        32515
-#define IDI_EXCLAMATION                 32515
 #define OCR_UP                          32516
 #define OIC_NOTE                        32516
-#define IDI_ASTERISK                    32516
 #define OIC_WINLOGO                     32517
-#define IDI_WINLOGO                     32517
 #define OIC_SHIELD                      32518
-#define IDI_SHIELD                      32518
 #define OCR_SIZE                        32640
 #define OCR_ICON                        32641
 #define OCR_SIZENWSE                    32642
@@ -1554,10 +1540,7 @@
 #define SC_CONTEXTHELP                  0xF180
 #define LVS_TYPESTYLEMASK               0xfc00
 #define SPVERSION_MASK                  0x0000FF00
-#define HTERROR                         -2
 #define UNICODE_NOCHAR                  0xFFFF
-#define PWR_FAIL                        -1
-#define HTTRANSPARENT                   -1
 
 // Next default values for new objects
 // 

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -1,5 +1,6 @@
 #include <stdafx.h>
 #include "File.h"
+#include "Shlwapi.h"
 
 File::File(std::wstring fileFullPath, int indexOfFile, int bufferIndex, int fileView)
 {

--- a/src/NppPlugin.cpp
+++ b/src/NppPlugin.cpp
@@ -18,7 +18,6 @@
 #include "stdafx.h"      //Pre-compiled header for compiler
 #include "PluginDefinition.h"
 #include "DockingFeature/NavigateToDlg.h"
-#include "ScintillaGateway.h"
 
 extern FuncItem funcItem[nbFunc];
 extern NppData nppData;

--- a/vs.proj/stdafx.h
+++ b/vs.proj/stdafx.h
@@ -1,4 +1,3 @@
-
 // stdafx.h : include file for standard system include files,
 // or project specific include files that are used frequently, but
 // are changed infrequently
@@ -14,13 +13,9 @@
 #define VC_EXTRALEAN            // Exclude rarely-used stuff from Windows headers
 #endif
 
-//#include <afxwin.h>         // MFC core and standard components
-
 #include <iostream>
 // Windows Header Files:
 #include <windows.h>
-#include "Shlwapi.h"
 
-#include <Commctrl.h>
 
 // TODO: reference additional headers your program requires here


### PR DESCRIPTION
- corrections for x64 build
- adapted build version to 1.12.2

, see corresponding appveyor build https://ci.appveyor.com/project/chcg/nppnavigateto/build/1.12.2.8
-> issues with debug build
- added logger for compiler warnings, with output at e.g. https://ci.appveyor.com/project/chcg/nppnavigateto/build/1.12.2.8/job/gd77epd437xw939y/messages