### PR TITLE
Select the text in the edit box when activating the search dialog

### DIFF
--- a/src/DockingFeature/NavigateToDlg.cpp
+++ b/src/DockingFeature/NavigateToDlg.cpp
@@ -247,17 +247,21 @@ INT_PTR CALLBACK NavigateToDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 {    
 	switch (message) 
 	{
-#ifndef _DEBUG
+
         case WM_ACTIVATE:
         {
+            HWND hwndEdit = GetWindow(hwndGoLineEdit, GW_CHILD);
+            SendMessage(hwndEdit, EM_SETSEL, 0, -1);
+#ifndef _DEBUG
             if (LOWORD(wParam) == WA_INACTIVE && isVisible() && !isDropDownOpened)
 			{
                 hide();
 			}
             isDropDownOpened = false;
+#endif
             return TRUE;
         }
-#endif
+
         case WM_KEYDOWN :
 		{
 			switch (wParam)


### PR DESCRIPTION
This makes it easier to start searching for a new file, as you don't have to manually select the text in order to delete it, or write over it.