### PR TITLE
bump .NET to v4.8, reduce directory searches

### DIFF
--- a/NppNavigateTo/Forms/FrmNavigateTo.cs
+++ b/NppNavigateTo/Forms/FrmNavigateTo.cs
@@ -42,6 +42,14 @@ namespace NavigateTo.Plugin.Namespace
 
         public List<string> SelectedFiles { get; set; }
 
+        public string[] filesInCurrentDirectory { get; set; }
+
+        public bool shouldReloadFilesInDirectory { get; set; }
+
+        public long lastDirectoryReloadTimeTicks { get; set; }
+
+        public bool isShuttingDown { get; set; }
+
         public bool IsFuzzyResult { get; set; }
 
         public FrmNavigateTo(IScintillaGateway editor, INotepadPPGateway notepad)
@@ -49,36 +57,61 @@ namespace NavigateTo.Plugin.Namespace
             this.editor = editor;
             this.notepad = notepad;
             this.SelectedFiles = new List<string>();
+            filesInCurrentDirectory = null;
+            shouldReloadFilesInDirectory = true;
             IsFuzzyResult = false;
             InitializeComponent();
             ReloadFileList();
             this.notepad.ReloadMenuItems();
         }
 
-        void SearchInCurrentDirectory(string s, string searchPattern1)
+        private static bool MatchesAllWordsInFilter(string s, string[] words)
+        {
+            return words.All(word => 
+                s.IndexOf(word, StringComparison.CurrentCultureIgnoreCase) >= 0
+            );
+        }
+
+        void SearchInCurrentDirectory(string[] words)
         {
             string currentFilePath = notepad.GetCurrentFileDirectory();
-            if (!String.IsNullOrWhiteSpace(currentFilePath))
+            if (string.IsNullOrWhiteSpace(currentFilePath))
+                return;
+            bool searchInSubDirs = FrmSettings.Settings.GetBoolSetting(Settings.searchInSubDirs);
+            long nextTimeToRefresh = lastDirectoryReloadTimeTicks +
+                10_000_000 * FrmSettings.Settings.GetIntSetting(Settings.secondsBetweenDirectoryScans); // 10 million ticks/sec
+            if (shouldReloadFilesInDirectory ||
+                filesInCurrentDirectory == null ||
+                DateTime.UtcNow.Ticks >= nextTimeToRefresh)
             {
-                bool searchInSubDirs = FrmSettings.Settings.GetBoolSetting(Settings.searchInSubDirs);
-                foreach (var filePath in Directory.GetFiles(currentFilePath, searchPattern1,
-                                 searchInSubDirs ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
-                             .AsParallel().Where(e =>
-                                 e.IndexOf(s, StringComparison.CurrentCultureIgnoreCase) >= 0 ||
-                                 e.Contains(s))
-                             .ToList())
+                // only load the files in current directory as needed
+                // the correct files to load will depend on the active buffer
+                filesInCurrentDirectory = Directory.GetFiles(
+                    currentFilePath,
+                    "*.*",
+                    searchInSubDirs ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly
+                );
+                shouldReloadFilesInDirectory = false;
+                lastDirectoryReloadTimeTicks = DateTime.UtcNow.Ticks;
+            }
+            foreach (var filePath in filesInCurrentDirectory
+                            .AsParallel().Where(fname => MatchesAllWordsInFilter(fname, words))
+                            .ToList())
+            {
+                if (!FilteredFileList.Exists(file => file.FilePath.Equals(filePath)))
                 {
-                    if (!FilteredFileList.Exists(file => file.FilePath.Equals(filePath)))
-                    {
-                        FilteredFileList.Add(new FileModel(Path.GetFileName(filePath), filePath, -1, -1,
-                            searchInSubDirs ? FOLDER_SUB : FOLDER_TOP, 0));
-                    }
+                    FilteredFileList.Add(new FileModel(Path.GetFileName(filePath), filePath, -1, -1,
+                        searchInSubDirs ? FOLDER_SUB : FOLDER_TOP, 0));
                 }
             }
         }
 
         public void FilterDataGrid(string filter)
         {
+            // a bunch of NPPN_BUFFERACTIVATED events fire when Notepad++ is shutting down
+            // which will lead to this being called repeatedly
+            if (isShuttingDown)
+                return;
             if (!string.IsNullOrEmpty(searchComboBox.Text)) filter = searchComboBox.Text;
 
             if (!string.IsNullOrWhiteSpace(filter))
@@ -117,16 +150,17 @@ namespace NavigateTo.Plugin.Namespace
             }
             else
             {
+                var words = filter.Split(' ').Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
                 searchInTabs(filter);
 
                 if (FrmSettings.Settings.GetBoolSetting(Settings.searchInCurrentFolder))
                 {
-                    SearchInCurrentDirectory(filter, searchPattern);
+                    SearchInCurrentDirectory(words);
                 }
 
                 if (FrmSettings.Settings.GetBoolSetting(Settings.searchMenuCommands))
                 {
-                    FilterMenuCommands(filter);
+                    FilterMenuCommands(words);
                 }
 
                 FilteredFileList.ForEach(file =>
@@ -181,13 +215,11 @@ namespace NavigateTo.Plugin.Namespace
                 if (FrmSettings.Settings.GetBoolSetting(Settings.preferFilenameResults))
                 {
                     FilteredFileList = FileList.AsParallel()
-                        .Where(e => words.All(word =>
-                            e.FileName.IndexOf(word, StringComparison.CurrentCultureIgnoreCase) >= 0))
+                        .Where(e => MatchesAllWordsInFilter(e.FileName, words))
                         .ToList();
 
                     FileList.AsParallel()
-                        .Where(e => words.All(word =>
-                            e.FilePath.IndexOf(filter, StringComparison.CurrentCultureIgnoreCase) >= 0))
+                        .Where(e => MatchesAllWordsInFilter(e.FilePath, words))
                         .ToList().ForEach(filePath =>
                             {
                                 if (!FilteredFileList.Exists(file => file.FilePath.Equals(filePath.FilePath)))
@@ -200,10 +232,10 @@ namespace NavigateTo.Plugin.Namespace
                 else
                 {
                     FilteredFileList = FileList.AsParallel()
-                        .Where(e => words.All(word =>
-                            e.FilePath.IndexOf(word, StringComparison.CurrentCultureIgnoreCase) >= 0 ||
-                            e.FileName.IndexOf(word, StringComparison.CurrentCultureIgnoreCase) >= 0))
-                        .ToList();
+                        .Where(e =>
+                            MatchesAllWordsInFilter(e.FilePath, words) ||
+                            MatchesAllWordsInFilter(e.FileName, words)
+                        ).ToList();
                 }
             }
 
@@ -236,11 +268,11 @@ namespace NavigateTo.Plugin.Namespace
             }
         }
 
-        private void FilterMenuCommands(string filter)
+        private void FilterMenuCommands(string[] filterWords)
         {
-            foreach (var nppMenuCmd in notepad.MainMenuItems.AsParallel().Where(e => e.Value.IndexOf(filter,
-                             StringComparison.CurrentCultureIgnoreCase) >= 0 ||
-                         e.Value.Contains(filter)).ToList())
+            foreach (var nppMenuCmd in notepad.MainMenuItems.AsParallel().Where(e => 
+                MatchesAllWordsInFilter(e.Value, filterWords)
+            ).ToList())
             {
                 FilteredFileList.Add(new FileModel(
                     nppMenuCmd.Key.ToString(),
@@ -251,6 +283,8 @@ namespace NavigateTo.Plugin.Namespace
 
         public void ReloadFileList()
         {
+            if (isShuttingDown)
+                return;
             if (FileList == null) FileList = new List<FileModel>();
             FileList.Clear();
             int firstViewCount =

--- a/NppNavigateTo/Forms/FrmNavigateTo.cs
+++ b/NppNavigateTo/Forms/FrmNavigateTo.cs
@@ -108,10 +108,6 @@ namespace NavigateTo.Plugin.Namespace
 
         public void FilterDataGrid(string filter)
         {
-            // a bunch of NPPN_BUFFERACTIVATED events fire when Notepad++ is shutting down
-            // which will lead to this being called repeatedly
-            if (isShuttingDown)
-                return;
             if (!string.IsNullOrEmpty(searchComboBox.Text)) filter = searchComboBox.Text;
 
             if (!string.IsNullOrWhiteSpace(filter))
@@ -283,8 +279,6 @@ namespace NavigateTo.Plugin.Namespace
 
         public void ReloadFileList()
         {
-            if (isShuttingDown)
-                return;
             if (FileList == null) FileList = new List<FileModel>();
             FileList.Clear();
             int firstViewCount =

--- a/NppNavigateTo/Forms/FrmSettings.cs
+++ b/NppNavigateTo/Forms/FrmSettings.cs
@@ -62,6 +62,7 @@ namespace NavigateTo.Plugin.Namespace
             numericUpDownMinGridWidth.Value = Settings.GetIntSetting(Settings.gridMinWidth);
             checkBoxSearchInFolder.Checked = Settings.GetBoolSetting(Settings.searchInCurrentFolder);
             checkBoxSearchInSubDirs.Checked = Settings.GetBoolSetting(Settings.searchInSubDirs);
+            numUpDownSecsBetweenDirectoryScans.Value = Settings.GetIntSetting(Settings.secondsBetweenDirectoryScans);
             checkBoxSearchMenu.Checked = Settings.GetBoolSetting(Settings.searchMenuCommands);
             checkBoxCleanSearch.Checked = Settings.GetBoolSetting(Settings.clearOnClose);
             checkBoxKeepSelected.Checked = Settings.GetBoolSetting(Settings.selectFirstRowOnFilter);
@@ -332,6 +333,11 @@ namespace NavigateTo.Plugin.Namespace
             }
 
             RefreshDataGridStyles();
+        }
+
+        private void secondsBetweenDirectoryScans_ValueChanged(object sender, EventArgs e)
+        {
+            Settings.SetIntSetting(Settings.secondsBetweenDirectoryScans, (int)numUpDownSecsBetweenDirectoryScans.Value);
         }
     }
 }

--- a/NppNavigateTo/Forms/FrmSettings.designer.cs
+++ b/NppNavigateTo/Forms/FrmSettings.designer.cs
@@ -44,11 +44,14 @@
             this.label5 = new System.Windows.Forms.Label();
             this.numericUpDownCharSearchLimit = new System.Windows.Forms.NumericUpDown();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.numUpDownSecsBetweenDirectoryScans = new System.Windows.Forms.NumericUpDown();
+            this.label7 = new System.Windows.Forms.Label();
             this.numericUpDownFuzzyness = new System.Windows.Forms.NumericUpDown();
             this.checkBoxFuzzySearch = new System.Windows.Forms.CheckBox();
             this.checkBoxFileNameResults = new System.Windows.Forms.CheckBox();
             this.checkBoxSearchMenu = new System.Windows.Forms.CheckBox();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.buttonRowBackgroud = new System.Windows.Forms.Button();
             this.gridBackground = new System.Windows.Forms.Button();
             this.buttonResetStyle = new System.Windows.Forms.Button();
             this.buttonSelectedRowText = new System.Windows.Forms.Button();
@@ -63,12 +66,12 @@
             this.ColumnPath = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnView = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.label2 = new System.Windows.Forms.Label();
-            this.buttonRowBackgroud = new System.Windows.Forms.Button();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMinGridWidth)).BeginInit();
             this.groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownCharSearchLimit)).BeginInit();
             this.groupBox3.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numUpDownSecsBetweenDirectoryScans)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownFuzzyness)).BeginInit();
             this.groupBox4.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridFileListPreview)).BeginInit();
@@ -77,9 +80,10 @@
             // keepOpenDlgCheckBox
             // 
             this.keepOpenDlgCheckBox.AutoSize = true;
-            this.keepOpenDlgCheckBox.Location = new System.Drawing.Point(6, 28);
+            this.keepOpenDlgCheckBox.Location = new System.Drawing.Point(8, 34);
+            this.keepOpenDlgCheckBox.Margin = new System.Windows.Forms.Padding(4);
             this.keepOpenDlgCheckBox.Name = "keepOpenDlgCheckBox";
-            this.keepOpenDlgCheckBox.Size = new System.Drawing.Size(114, 17);
+            this.keepOpenDlgCheckBox.Size = new System.Drawing.Size(144, 20);
             this.keepOpenDlgCheckBox.TabIndex = 2;
             this.keepOpenDlgCheckBox.Text = "Keep dialog visible";
             this.keepOpenDlgCheckBox.UseVisualStyleBackColor = true;
@@ -90,9 +94,11 @@
             this.groupBox1.Controls.Add(this.checkBoxKeepSelected);
             this.groupBox1.Controls.Add(this.checkBoxCleanSearch);
             this.groupBox1.Controls.Add(this.keepOpenDlgCheckBox);
-            this.groupBox1.Location = new System.Drawing.Point(12, 12);
+            this.groupBox1.Location = new System.Drawing.Point(16, 15);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(283, 111);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox1.Size = new System.Drawing.Size(377, 137);
             this.groupBox1.TabIndex = 4;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "General";
@@ -100,9 +106,10 @@
             // checkBoxKeepSelected
             // 
             this.checkBoxKeepSelected.AutoSize = true;
-            this.checkBoxKeepSelected.Location = new System.Drawing.Point(6, 74);
+            this.checkBoxKeepSelected.Location = new System.Drawing.Point(8, 91);
+            this.checkBoxKeepSelected.Margin = new System.Windows.Forms.Padding(4);
             this.checkBoxKeepSelected.Name = "checkBoxKeepSelected";
-            this.checkBoxKeepSelected.Size = new System.Drawing.Size(143, 17);
+            this.checkBoxKeepSelected.Size = new System.Drawing.Size(176, 20);
             this.checkBoxKeepSelected.TabIndex = 4;
             this.checkBoxKeepSelected.Text = "Keep First Row Selected";
             this.checkBoxKeepSelected.UseVisualStyleBackColor = true;
@@ -111,9 +118,10 @@
             // checkBoxCleanSearch
             // 
             this.checkBoxCleanSearch.AutoSize = true;
-            this.checkBoxCleanSearch.Location = new System.Drawing.Point(6, 51);
+            this.checkBoxCleanSearch.Location = new System.Drawing.Point(8, 63);
+            this.checkBoxCleanSearch.Margin = new System.Windows.Forms.Padding(4);
             this.checkBoxCleanSearch.Name = "checkBoxCleanSearch";
-            this.checkBoxCleanSearch.Size = new System.Drawing.Size(111, 17);
+            this.checkBoxCleanSearch.Size = new System.Drawing.Size(136, 20);
             this.checkBoxCleanSearch.TabIndex = 3;
             this.checkBoxCleanSearch.Text = "Clear search input";
             this.checkBoxCleanSearch.UseVisualStyleBackColor = true;
@@ -122,9 +130,10 @@
             // checkBoxSearchInFolder
             // 
             this.checkBoxSearchInFolder.AutoSize = true;
-            this.checkBoxSearchInFolder.Location = new System.Drawing.Point(6, 19);
+            this.checkBoxSearchInFolder.Location = new System.Drawing.Point(8, 23);
+            this.checkBoxSearchInFolder.Margin = new System.Windows.Forms.Padding(4);
             this.checkBoxSearchInFolder.Name = "checkBoxSearchInFolder";
-            this.checkBoxSearchInFolder.Size = new System.Drawing.Size(251, 17);
+            this.checkBoxSearchInFolder.Size = new System.Drawing.Size(337, 21);
             this.checkBoxSearchInFolder.TabIndex = 5;
             this.checkBoxSearchInFolder.Text = "Search in current file folder ( Top directory only )";
             this.checkBoxSearchInFolder.UseVisualStyleBackColor = true;
@@ -133,9 +142,10 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(67, 29);
+            this.label1.Location = new System.Drawing.Point(89, 36);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(77, 13);
+            this.label1.Size = new System.Drawing.Size(93, 16);
             this.label1.TabIndex = 5;
             this.label1.Text = "Min Grid Width";
             // 
@@ -146,7 +156,8 @@
             0,
             0,
             0});
-            this.numericUpDownMinGridWidth.Location = new System.Drawing.Point(12, 25);
+            this.numericUpDownMinGridWidth.Location = new System.Drawing.Point(16, 31);
+            this.numericUpDownMinGridWidth.Margin = new System.Windows.Forms.Padding(4);
             this.numericUpDownMinGridWidth.Maximum = new decimal(new int[] {
             5000,
             0,
@@ -158,7 +169,7 @@
             0,
             0});
             this.numericUpDownMinGridWidth.Name = "numericUpDownMinGridWidth";
-            this.numericUpDownMinGridWidth.Size = new System.Drawing.Size(49, 20);
+            this.numericUpDownMinGridWidth.Size = new System.Drawing.Size(65, 22);
             this.numericUpDownMinGridWidth.TabIndex = 4;
             this.numericUpDownMinGridWidth.Value = new decimal(new int[] {
             250,
@@ -170,9 +181,10 @@
             // checkBoxSearchInSubDirs
             // 
             this.checkBoxSearchInSubDirs.AutoSize = true;
-            this.checkBoxSearchInSubDirs.Location = new System.Drawing.Point(26, 42);
+            this.checkBoxSearchInSubDirs.Location = new System.Drawing.Point(35, 52);
+            this.checkBoxSearchInSubDirs.Margin = new System.Windows.Forms.Padding(4);
             this.checkBoxSearchInSubDirs.Name = "checkBoxSearchInSubDirs";
-            this.checkBoxSearchInSubDirs.Size = new System.Drawing.Size(160, 17);
+            this.checkBoxSearchInSubDirs.Size = new System.Drawing.Size(211, 21);
             this.checkBoxSearchInSubDirs.TabIndex = 5;
             this.checkBoxSearchInSubDirs.Text = "Search in sub directories too";
             this.checkBoxSearchInSubDirs.UseVisualStyleBackColor = true;
@@ -187,9 +199,11 @@
             this.groupBox2.Controls.Add(this.numericUpDownCharSearchLimit);
             this.groupBox2.Controls.Add(this.label1);
             this.groupBox2.Controls.Add(this.numericUpDownMinGridWidth);
-            this.groupBox2.Location = new System.Drawing.Point(311, 12);
+            this.groupBox2.Location = new System.Drawing.Point(415, 15);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(256, 111);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox2.Size = new System.Drawing.Size(341, 137);
             this.groupBox2.TabIndex = 6;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "File List";
@@ -201,9 +215,10 @@
             this.comboBoxSortOrder.Items.AddRange(new object[] {
             "ASC",
             "DESC"});
-            this.comboBoxSortOrder.Location = new System.Drawing.Point(179, 80);
+            this.comboBoxSortOrder.Location = new System.Drawing.Point(239, 98);
+            this.comboBoxSortOrder.Margin = new System.Windows.Forms.Padding(4);
             this.comboBoxSortOrder.Name = "comboBoxSortOrder";
-            this.comboBoxSortOrder.Size = new System.Drawing.Size(53, 21);
+            this.comboBoxSortOrder.Size = new System.Drawing.Size(69, 24);
             this.comboBoxSortOrder.TabIndex = 10;
             this.comboBoxSortOrder.SelectedIndexChanged += new System.EventHandler(this.comboBoxSortOrder_SelectedIndexChanged);
             // 
@@ -215,33 +230,37 @@
             "-",
             "Name",
             "Path"});
-            this.comboBoxSortedByAfterFilter.Location = new System.Drawing.Point(120, 80);
+            this.comboBoxSortedByAfterFilter.Location = new System.Drawing.Point(160, 98);
+            this.comboBoxSortedByAfterFilter.Margin = new System.Windows.Forms.Padding(4);
             this.comboBoxSortedByAfterFilter.Name = "comboBoxSortedByAfterFilter";
-            this.comboBoxSortedByAfterFilter.Size = new System.Drawing.Size(53, 21);
+            this.comboBoxSortedByAfterFilter.Size = new System.Drawing.Size(69, 24);
             this.comboBoxSortedByAfterFilter.TabIndex = 9;
             this.comboBoxSortedByAfterFilter.SelectedIndexChanged += new System.EventHandler(this.comboBoxSortedByAfterFilter_SelectedIndexChanged);
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(12, 83);
+            this.label6.Location = new System.Drawing.Point(16, 102);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(102, 13);
+            this.label6.Size = new System.Drawing.Size(125, 16);
             this.label6.TabIndex = 8;
             this.label6.Text = "Sort after search by:";
             // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(67, 58);
+            this.label5.Location = new System.Drawing.Point(89, 71);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(86, 13);
+            this.label5.Size = new System.Drawing.Size(105, 16);
             this.label5.TabIndex = 7;
             this.label5.Text = "Min Char Search";
             // 
             // numericUpDownCharSearchLimit
             // 
-            this.numericUpDownCharSearchLimit.Location = new System.Drawing.Point(12, 56);
+            this.numericUpDownCharSearchLimit.Location = new System.Drawing.Point(16, 69);
+            this.numericUpDownCharSearchLimit.Margin = new System.Windows.Forms.Padding(4);
             this.numericUpDownCharSearchLimit.Maximum = new decimal(new int[] {
             10,
             0,
@@ -253,7 +272,7 @@
             0,
             0});
             this.numericUpDownCharSearchLimit.Name = "numericUpDownCharSearchLimit";
-            this.numericUpDownCharSearchLimit.Size = new System.Drawing.Size(49, 20);
+            this.numericUpDownCharSearchLimit.Size = new System.Drawing.Size(65, 22);
             this.numericUpDownCharSearchLimit.TabIndex = 6;
             this.numericUpDownCharSearchLimit.Value = new decimal(new int[] {
             2,
@@ -264,6 +283,8 @@
             // 
             // groupBox3
             // 
+            this.groupBox3.Controls.Add(this.numUpDownSecsBetweenDirectoryScans);
+            this.groupBox3.Controls.Add(this.label7);
             this.groupBox3.Controls.Add(this.numericUpDownFuzzyness);
             this.groupBox3.Controls.Add(this.checkBoxFuzzySearch);
             this.groupBox3.Controls.Add(this.checkBoxFileNameResults);
@@ -271,23 +292,59 @@
             this.groupBox3.Controls.Add(this.checkBoxSearchInFolder);
             this.groupBox3.Controls.Add(this.checkBoxSearchInSubDirs);
             this.groupBox3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.groupBox3.Location = new System.Drawing.Point(12, 129);
+            this.groupBox3.Location = new System.Drawing.Point(16, 159);
+            this.groupBox3.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(283, 137);
+            this.groupBox3.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox3.Size = new System.Drawing.Size(377, 185);
             this.groupBox3.TabIndex = 7;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Search behavior";
             // 
+            // numUpDownSecsBetweenDirectoryScans
+            // 
+            this.numUpDownSecsBetweenDirectoryScans.Location = new System.Drawing.Point(288, 75);
+            this.numUpDownSecsBetweenDirectoryScans.Margin = new System.Windows.Forms.Padding(4);
+            this.numUpDownSecsBetweenDirectoryScans.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.numUpDownSecsBetweenDirectoryScans.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numUpDownSecsBetweenDirectoryScans.Name = "numUpDownSecsBetweenDirectoryScans";
+            this.numUpDownSecsBetweenDirectoryScans.Size = new System.Drawing.Size(53, 23);
+            this.numUpDownSecsBetweenDirectoryScans.TabIndex = 13;
+            this.numUpDownSecsBetweenDirectoryScans.Value = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.numUpDownSecsBetweenDirectoryScans.ValueChanged += new System.EventHandler(this.secondsBetweenDirectoryScans_ValueChanged);
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(7, 77);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(241, 17);
+            this.label7.TabIndex = 12;
+            this.label7.Text = "Refresh file list how often? (seconds)";
+            // 
             // numericUpDownFuzzyness
             // 
-            this.numericUpDownFuzzyness.Location = new System.Drawing.Point(217, 107);
+            this.numericUpDownFuzzyness.Location = new System.Drawing.Point(288, 153);
+            this.numericUpDownFuzzyness.Margin = new System.Windows.Forms.Padding(4);
             this.numericUpDownFuzzyness.Maximum = new decimal(new int[] {
             10,
             0,
             0,
             0});
             this.numericUpDownFuzzyness.Name = "numericUpDownFuzzyness";
-            this.numericUpDownFuzzyness.Size = new System.Drawing.Size(40, 20);
+            this.numericUpDownFuzzyness.Size = new System.Drawing.Size(53, 23);
             this.numericUpDownFuzzyness.TabIndex = 11;
             this.numericUpDownFuzzyness.Value = new decimal(new int[] {
             1,
@@ -299,9 +356,10 @@
             // checkBoxFuzzySearch
             // 
             this.checkBoxFuzzySearch.AutoSize = true;
-            this.checkBoxFuzzySearch.Location = new System.Drawing.Point(6, 110);
+            this.checkBoxFuzzySearch.Location = new System.Drawing.Point(7, 156);
+            this.checkBoxFuzzySearch.Margin = new System.Windows.Forms.Padding(4);
             this.checkBoxFuzzySearch.Name = "checkBoxFuzzySearch";
-            this.checkBoxFuzzySearch.Size = new System.Drawing.Size(205, 17);
+            this.checkBoxFuzzySearch.Size = new System.Drawing.Size(274, 21);
             this.checkBoxFuzzySearch.TabIndex = 8;
             this.checkBoxFuzzySearch.Text = "Fuzzy search (Tabs Only) - Tolerance:";
             this.checkBoxFuzzySearch.UseVisualStyleBackColor = true;
@@ -310,9 +368,10 @@
             // checkBoxFileNameResults
             // 
             this.checkBoxFileNameResults.AutoSize = true;
-            this.checkBoxFileNameResults.Location = new System.Drawing.Point(6, 87);
+            this.checkBoxFileNameResults.Location = new System.Drawing.Point(7, 128);
+            this.checkBoxFileNameResults.Margin = new System.Windows.Forms.Padding(4);
             this.checkBoxFileNameResults.Name = "checkBoxFileNameResults";
-            this.checkBoxFileNameResults.Size = new System.Drawing.Size(144, 17);
+            this.checkBoxFileNameResults.Size = new System.Drawing.Size(190, 21);
             this.checkBoxFileNameResults.TabIndex = 7;
             this.checkBoxFileNameResults.Text = "Prefer filename over path";
             this.checkBoxFileNameResults.UseVisualStyleBackColor = true;
@@ -321,9 +380,10 @@
             // checkBoxSearchMenu
             // 
             this.checkBoxSearchMenu.AutoSize = true;
-            this.checkBoxSearchMenu.Location = new System.Drawing.Point(6, 65);
+            this.checkBoxSearchMenu.Location = new System.Drawing.Point(7, 101);
+            this.checkBoxSearchMenu.Margin = new System.Windows.Forms.Padding(4);
             this.checkBoxSearchMenu.Name = "checkBoxSearchMenu";
-            this.checkBoxSearchMenu.Size = new System.Drawing.Size(211, 17);
+            this.checkBoxSearchMenu.Size = new System.Drawing.Size(280, 21);
             this.checkBoxSearchMenu.TabIndex = 6;
             this.checkBoxSearchMenu.Text = "Search menu commands (experimental)";
             this.checkBoxSearchMenu.UseVisualStyleBackColor = true;
@@ -340,18 +400,32 @@
             this.groupBox4.Controls.Add(this.label3);
             this.groupBox4.Controls.Add(this.buttonGridTextColor);
             this.groupBox4.Controls.Add(this.button1);
-            this.groupBox4.Location = new System.Drawing.Point(311, 129);
+            this.groupBox4.Location = new System.Drawing.Point(415, 159);
+            this.groupBox4.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(256, 137);
+            this.groupBox4.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox4.Size = new System.Drawing.Size(341, 184);
             this.groupBox4.TabIndex = 8;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Appearance";
             // 
+            // buttonRowBackgroud
+            // 
+            this.buttonRowBackgroud.Location = new System.Drawing.Point(16, 135);
+            this.buttonRowBackgroud.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonRowBackgroud.Name = "buttonRowBackgroud";
+            this.buttonRowBackgroud.Size = new System.Drawing.Size(152, 28);
+            this.buttonRowBackgroud.TabIndex = 9;
+            this.buttonRowBackgroud.Text = "Row Background";
+            this.buttonRowBackgroud.UseVisualStyleBackColor = true;
+            this.buttonRowBackgroud.Click += new System.EventHandler(this.buttonRowBackgroud_Click);
+            // 
             // gridBackground
             // 
-            this.gridBackground.Location = new System.Drawing.Point(12, 83);
+            this.gridBackground.Location = new System.Drawing.Point(16, 102);
+            this.gridBackground.Margin = new System.Windows.Forms.Padding(4);
             this.gridBackground.Name = "gridBackground";
-            this.gridBackground.Size = new System.Drawing.Size(114, 23);
+            this.gridBackground.Size = new System.Drawing.Size(152, 28);
             this.gridBackground.TabIndex = 8;
             this.gridBackground.Text = "Grid Background";
             this.gridBackground.UseVisualStyleBackColor = true;
@@ -359,9 +433,10 @@
             // 
             // buttonResetStyle
             // 
-            this.buttonResetStyle.Location = new System.Drawing.Point(203, 94);
+            this.buttonResetStyle.Location = new System.Drawing.Point(271, 116);
+            this.buttonResetStyle.Margin = new System.Windows.Forms.Padding(4);
             this.buttonResetStyle.Name = "buttonResetStyle";
-            this.buttonResetStyle.Size = new System.Drawing.Size(47, 23);
+            this.buttonResetStyle.Size = new System.Drawing.Size(63, 28);
             this.buttonResetStyle.TabIndex = 7;
             this.buttonResetStyle.Text = "Reset";
             this.buttonResetStyle.UseVisualStyleBackColor = true;
@@ -369,9 +444,10 @@
             // 
             // buttonSelectedRowText
             // 
-            this.buttonSelectedRowText.Location = new System.Drawing.Point(179, 53);
+            this.buttonSelectedRowText.Location = new System.Drawing.Point(239, 65);
+            this.buttonSelectedRowText.Margin = new System.Windows.Forms.Padding(4);
             this.buttonSelectedRowText.Name = "buttonSelectedRowText";
-            this.buttonSelectedRowText.Size = new System.Drawing.Size(40, 23);
+            this.buttonSelectedRowText.Size = new System.Drawing.Size(53, 28);
             this.buttonSelectedRowText.TabIndex = 6;
             this.buttonSelectedRowText.Text = "Text";
             this.buttonSelectedRowText.UseVisualStyleBackColor = true;
@@ -379,9 +455,10 @@
             // 
             // buttonSelectedRowBack
             // 
-            this.buttonSelectedRowBack.Location = new System.Drawing.Point(99, 53);
+            this.buttonSelectedRowBack.Location = new System.Drawing.Point(132, 65);
+            this.buttonSelectedRowBack.Margin = new System.Windows.Forms.Padding(4);
             this.buttonSelectedRowBack.Name = "buttonSelectedRowBack";
-            this.buttonSelectedRowBack.Size = new System.Drawing.Size(74, 23);
+            this.buttonSelectedRowBack.Size = new System.Drawing.Size(99, 28);
             this.buttonSelectedRowBack.TabIndex = 5;
             this.buttonSelectedRowBack.Text = "Background";
             this.buttonSelectedRowBack.UseVisualStyleBackColor = true;
@@ -390,26 +467,29 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(9, 58);
+            this.label4.Location = new System.Drawing.Point(12, 71);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(74, 13);
+            this.label4.Size = new System.Drawing.Size(91, 16);
             this.label4.TabIndex = 4;
             this.label4.Text = "Selected Row";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(9, 24);
+            this.label3.Location = new System.Drawing.Point(12, 30);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(48, 13);
+            this.label3.Size = new System.Drawing.Size(59, 16);
             this.label3.TabIndex = 3;
             this.label3.Text = "Highlight";
             // 
             // buttonGridTextColor
             // 
-            this.buttonGridTextColor.Location = new System.Drawing.Point(179, 19);
+            this.buttonGridTextColor.Location = new System.Drawing.Point(239, 23);
+            this.buttonGridTextColor.Margin = new System.Windows.Forms.Padding(4);
             this.buttonGridTextColor.Name = "buttonGridTextColor";
-            this.buttonGridTextColor.Size = new System.Drawing.Size(40, 23);
+            this.buttonGridTextColor.Size = new System.Drawing.Size(53, 28);
             this.buttonGridTextColor.TabIndex = 2;
             this.buttonGridTextColor.Text = "Text";
             this.buttonGridTextColor.UseVisualStyleBackColor = true;
@@ -417,9 +497,10 @@
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(99, 19);
+            this.button1.Location = new System.Drawing.Point(132, 23);
+            this.button1.Margin = new System.Windows.Forms.Padding(4);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(74, 23);
+            this.button1.Size = new System.Drawing.Size(99, 28);
             this.button1.TabIndex = 1;
             this.button1.Text = "Background";
             this.button1.UseVisualStyleBackColor = true;
@@ -449,13 +530,15 @@
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
             this.dataGridFileListPreview.DefaultCellStyle = dataGridViewCellStyle1;
-            this.dataGridFileListPreview.Location = new System.Drawing.Point(12, 285);
+            this.dataGridFileListPreview.Location = new System.Drawing.Point(16, 378);
+            this.dataGridFileListPreview.Margin = new System.Windows.Forms.Padding(4);
             this.dataGridFileListPreview.Name = "dataGridFileListPreview";
             this.dataGridFileListPreview.ReadOnly = true;
             this.dataGridFileListPreview.RowHeadersVisible = false;
+            this.dataGridFileListPreview.RowHeadersWidth = 51;
             this.dataGridFileListPreview.RowTemplate.ReadOnly = true;
             this.dataGridFileListPreview.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dataGridFileListPreview.Size = new System.Drawing.Size(555, 144);
+            this.dataGridFileListPreview.Size = new System.Drawing.Size(740, 195);
             this.dataGridFileListPreview.TabIndex = 9;
             this.dataGridFileListPreview.CellPainting += new System.Windows.Forms.DataGridViewCellPaintingEventHandler(this.dataGridFileListPreview_CellPainting);
             this.dataGridFileListPreview.ColumnWidthChanged += new System.Windows.Forms.DataGridViewColumnEventHandler(this.dataGridFileListPreview_ColumnWidthChanged);
@@ -490,33 +573,25 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(15, 269);
+            this.label2.Location = new System.Drawing.Point(20, 353);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(48, 13);
+            this.label2.Size = new System.Drawing.Size(58, 16);
             this.label2.TabIndex = 10;
             this.label2.Text = "Preview:";
             // 
-            // buttonRowBackgroud
-            // 
-            this.buttonRowBackgroud.Location = new System.Drawing.Point(12, 110);
-            this.buttonRowBackgroud.Name = "buttonRowBackgroud";
-            this.buttonRowBackgroud.Size = new System.Drawing.Size(114, 23);
-            this.buttonRowBackgroud.TabIndex = 9;
-            this.buttonRowBackgroud.Text = "Row Background";
-            this.buttonRowBackgroud.UseVisualStyleBackColor = true;
-            this.buttonRowBackgroud.Click += new System.EventHandler(this.buttonRowBackgroud_Click);
-            // 
             // FrmSettings
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(579, 443);
+            this.ClientSize = new System.Drawing.Size(772, 583);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.dataGridFileListPreview);
             this.Controls.Add(this.groupBox4);
             this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "FrmSettings";
             this.ShowIcon = false;
             this.Text = "Navigate To - Settings";
@@ -532,6 +607,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownCharSearchLimit)).EndInit();
             this.groupBox3.ResumeLayout(false);
             this.groupBox3.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numUpDownSecsBetweenDirectoryScans)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownFuzzyness)).EndInit();
             this.groupBox4.ResumeLayout(false);
             this.groupBox4.PerformLayout();
@@ -577,5 +653,7 @@
         private System.Windows.Forms.CheckBox checkBoxFuzzySearch;
         private System.Windows.Forms.NumericUpDown numericUpDownFuzzyness;
         private System.Windows.Forms.Button buttonRowBackgroud;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.NumericUpDown numUpDownSecsBetweenDirectoryScans;
     }
 }

--- a/NppNavigateTo/NppNavigateTo.csproj
+++ b/NppNavigateTo/NppNavigateTo.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NppPluginNET</RootNamespace>
     <AssemblyName>NavigateTo</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <OldToolsVersion>3.5</OldToolsVersion>
     <ProjectGuid>{EB8FC3A3-93E8-457B-B281-FAFA5119611A}</ProjectGuid>
   </PropertyGroup>

--- a/NppNavigateTo/Settings.cs
+++ b/NppNavigateTo/Settings.cs
@@ -33,6 +33,7 @@ namespace NppPluginNET
         public static string sortOrderAfterFilterBy = "sortOrderAfterFilterBy";
         public static string fuzzySearch = "fuzzySearch";
         public static string fuzzynessTolerance = "fuzzynessTolerance";
+        public static string secondsBetweenDirectoryScans = "secondsBetweenDirectoryScans";
 
         static string iniFilePath;
         static string lpAppName = "NavigateTo";
@@ -146,6 +147,7 @@ namespace NppPluginNET
                 Win32.GetPrivateProfileInt(lpAppName, fuzzynessTolerance, 1, iniFilePath));
             LoadIntSetting(rowBackgroundColor,
                 Win32.GetPrivateProfileInt(lpAppName, rowBackgroundColor, -1, iniFilePath));
+            LoadIntSetting(secondsBetweenDirectoryScans, Win32.GetPrivateProfileInt(lpAppName, secondsBetweenDirectoryScans, 5, iniFilePath));
         }
 
         public void SetColorSetting(String name, Color color)


### PR DESCRIPTION
Would close issues #40 and #39.

1. Update .NET Framework to 4.8. This may not be necessary, but I can't compile this project without it. If you want to change this back to 4.0 before your next release, fine by me.
2. Add a check if Notepad++ is shutting down before updating file list (`NPPN_BUFFERACTIVATED` events fire when Notepad++ is shutting down, but the user doesn't care about the file list at that point)
3. When files in the current file's directory are queried, only update those files at the following times:
    * frmNavigateTo is visible AND
    * if no files in directory list exists yet OR
    * when a new buffer is activated OR
    * if the last refresh of the files in directory list was at least N seconds ago (where N is the value of the `Settings.secondsBetweenDirectoryScans` variable, default 5)
5. Because querying the files in the directory is much faster now, change the search algorithm so that it checks if all words in the search box are in the current file's directory and the menu commands (to be consistent with the behavior for searching tabs)