### PR TITLE
add dark mode support, warnings for big dirs

### DIFF
--- a/NppNavigateTo/FormStyle.cs
+++ b/NppNavigateTo/FormStyle.cs
@@ -1,0 +1,180 @@
+﻿using Kbg.NppPluginNET.PluginInfrastructure;
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace NavigateTo.Plugin.Namespace
+{
+    public class FormStyle
+    {
+        public static Color SlightlyDarkControl = Color.FromArgb(
+            3 * SystemColors.Control.R / 4 + SystemColors.ControlDark.R / 4,
+            3 * SystemColors.Control.G / 4 + SystemColors.ControlDark.G / 4,
+            3 * SystemColors.Control.B / 4 + SystemColors.ControlDark.B / 4
+        );
+
+
+        /// <summary>
+        /// Changes the background and text color of the form
+        /// and any child forms to match the editor window.<br></br>
+        /// Fires when the form is first opened
+        /// and also whenever the style is changed.<br></br>
+        /// Heavily based on CsvQuery (https://github.com/jokedst/CsvQuery)
+        /// </summary>
+        public static void ApplyStyle(Control ctrl, bool use_npp_style, bool isDark = false)
+        {
+            if (ctrl == null || ctrl.IsDisposed) return;
+            int[] version = Main.notepad.GetNppVersion();
+            if (version[0] < 8)
+                use_npp_style = false; // trying to follow editor style looks weird for Notepad++ 7.3.3
+            if (ctrl is Form form)
+            {
+                foreach (Form childForm in form.OwnedForms)
+                {
+                    ApplyStyle(childForm, use_npp_style, isDark);
+                }
+            }
+            Color backColor = Main.notepad.GetDefaultBackgroundColor();
+            Color foreColor = Main.notepad.GetDefaultForegroundColor();
+            Color InBetween = Color.FromArgb(
+                foreColor.R / 4 + 3 * backColor.R / 4,
+                foreColor.G / 4 + 3 * backColor.G / 4,
+                foreColor.B / 4 + 3 * backColor.B / 4
+            );
+            IntPtr themePtr = Main.notepad.GetDarkModeColors();
+            if (isDark && themePtr != IntPtr.Zero)
+            {
+                var theme = (DarkModeColors)Marshal.PtrToStructure(themePtr, typeof(DarkModeColors));
+                ctrl.BackColor = NppDarkMode.BGRToColor(theme.Background);
+                ctrl.ForeColor = NppDarkMode.BGRToColor(theme.Text);
+                foreach (Control child in ctrl.Controls)
+                {
+                    // this doesn't actually make disabled controls have different colors
+                    // windows forms don't make it easy for the user to choose the
+                    // color of a disabled control. See https://stackoverflow.com/questions/136129/windows-forms-how-do-you-change-the-font-color-for-a-disabled-label
+                    var textTheme = child.Enabled ? theme.Text : theme.DisabledText;
+                    if (child is GroupBox)
+                        ApplyStyle(child, use_npp_style, isDark);
+                    else if (child is Button btn)
+                    {
+                        btn.BackColor = NppDarkMode.BGRToColor(theme.SofterBackground);
+                        btn.ForeColor = NppDarkMode.BGRToColor(textTheme);
+                    }
+                    else if (child is LinkLabel llbl)
+                    {
+                        llbl.BackColor = NppDarkMode.BGRToColor(theme.PureBackground);
+                        llbl.ForeColor = NppDarkMode.BGRToColor(textTheme);
+                        llbl.LinkColor = NppDarkMode.BGRToColor(theme.LinkText);
+                        llbl.ActiveLinkColor = NppDarkMode.BGRToColor(textTheme);
+                        llbl.VisitedLinkColor = NppDarkMode.BGRToColor(theme.DarkerText);
+                    }
+                    // other common text-based controls
+                    else if (child is TextBox
+                        || child is Label
+                        || child is ListBox
+                        || child is ComboBox)
+                    {
+                        child.BackColor = NppDarkMode.BGRToColor(theme.PureBackground);
+                        child.ForeColor = NppDarkMode.BGRToColor(textTheme);
+                    }
+                    else if (child is TreeView tv)
+                    {
+                        tv.BackColor = NppDarkMode.BGRToColor(theme.HotBackground);
+                        tv.ForeColor = NppDarkMode.BGRToColor(textTheme);
+                    }
+                    else if (child is DataGridView dgv)
+                    {
+                        // for reasons that I cannot fathom, everything EXCEPT the background gets correctly colored
+                        // when you first open the form in dark mode.
+                        // The background is untouched by the current style until you change to another style and then back,
+                        // at which point the background remembers what color it's supposed to be. Very odd.
+                        dgv.BackgroundColor = InBetween;
+                        dgv.ForeColor = NppDarkMode.BGRToColor(textTheme);
+                        dgv.GridColor = NppDarkMode.BGRToColor(theme.HotBackground);
+                        dgv.RowHeadersDefaultCellStyle.ForeColor = NppDarkMode.BGRToColor(textTheme);
+                        dgv.RowHeadersDefaultCellStyle.BackColor = NppDarkMode.BGRToColor(theme.PureBackground);
+                        dgv.RowsDefaultCellStyle.ForeColor = NppDarkMode.BGRToColor(textTheme);
+                        dgv.RowsDefaultCellStyle.BackColor = NppDarkMode.BGRToColor(theme.PureBackground);
+                    }
+                    else
+                    {
+                        // other controls I haven't thought of yet
+                        child.BackColor = NppDarkMode.BGRToColor(theme.SofterBackground);
+                        child.ForeColor = NppDarkMode.BGRToColor(textTheme);
+                    }
+                }
+                Marshal.FreeHGlobal(themePtr);
+                return;
+            }
+            else if (!use_npp_style || (
+                backColor.R > 240 &&
+                backColor.G > 240 &&
+                backColor.B > 240))
+            {
+                // if the background is basically white,
+                // use the system defaults because they
+                // look best on a white or nearly white background
+                ctrl.BackColor = SystemColors.Control;
+                ctrl.ForeColor = SystemColors.ControlText;
+                foreach (Control child in ctrl.Controls)
+                {
+                    if (child is GroupBox)
+                        ApplyStyle(child, use_npp_style, isDark);
+                    // controls containing text
+                    else if (child is TextBox || child is ListBox || child is ComboBox || child is TreeView)
+                    {
+                        child.BackColor = SystemColors.Window; // white background
+                        child.ForeColor = SystemColors.WindowText;
+                    }
+                    else if (child is LinkLabel llbl)
+                    {
+                        llbl.LinkColor = Color.Blue;
+                        llbl.ActiveLinkColor = Color.Red;
+                        llbl.VisitedLinkColor = Color.Purple;
+                    }
+                    else if (child is DataGridView dgv)
+                    {
+                        dgv.BackgroundColor = SystemColors.ControlDark;
+                        dgv.ForeColor = SystemColors.ControlText;
+                        dgv.GridColor = SystemColors.ControlDarkDark;
+                        dgv.RowHeadersDefaultCellStyle.ForeColor = SystemColors.WindowText;
+                        dgv.RowHeadersDefaultCellStyle.BackColor = SystemColors.Window;
+                        dgv.RowsDefaultCellStyle.ForeColor = SystemColors.ControlText;
+                        dgv.RowsDefaultCellStyle.BackColor = SystemColors.Window;
+                    }
+                    else
+                    {
+                        // buttons should be a bit darker but everything else is the same color as the background
+                        child.BackColor = (child is Button) ? SlightlyDarkControl : SystemColors.Control;
+                        child.ForeColor = SystemColors.ControlText;
+                    }
+                }
+                return;
+            }
+            // use NPP styling for non-dark-mode
+            ctrl.BackColor = backColor;
+            foreach (Control child in ctrl.Controls)
+            {
+                child.BackColor = backColor;
+                child.ForeColor = foreColor;
+                if (child is LinkLabel llbl)
+                {
+                    llbl.LinkColor = foreColor;
+                    llbl.ActiveLinkColor = foreColor;
+                    llbl.VisitedLinkColor = foreColor;
+                }
+                else if (child is DataGridView dgv)
+                {
+                    dgv.BackgroundColor = InBetween;
+                    dgv.ForeColor = foreColor;
+                    dgv.GridColor = foreColor;
+                    dgv.RowHeadersDefaultCellStyle.ForeColor = foreColor;
+                    dgv.RowHeadersDefaultCellStyle.BackColor = backColor;
+                    dgv.RowsDefaultCellStyle.ForeColor = foreColor;
+                    dgv.RowsDefaultCellStyle.BackColor = backColor;
+                }
+            }
+        }
+    }
+}

--- a/NppNavigateTo/Forms/AboutForm.cs
+++ b/NppNavigateTo/Forms/AboutForm.cs
@@ -17,6 +17,7 @@ namespace NavigateTo.Plugin.Namespace
         {
             InitializeComponent();
             Title.Text = $"NavigateTo v{AssemblyVersionString()}";
+            FormStyle.ApplyStyle(this, true, Main.notepad.IsDarkModeEnabled());
         }
 
         /// <summary>

--- a/NppNavigateTo/Forms/FrmSettings.cs
+++ b/NppNavigateTo/Forms/FrmSettings.cs
@@ -23,6 +23,7 @@ namespace NavigateTo.Plugin.Namespace
             this.notepad = notepad;
             InitializeComponent();
             Settings.LoadConfigValues();
+            FormStyle.ApplyStyle(this, true, notepad.IsDarkModeEnabled());
         }
 
         private void frmSettings_Load(object sender, EventArgs e)

--- a/NppNavigateTo/NppNavigateTo.cs
+++ b/NppNavigateTo/NppNavigateTo.cs
@@ -15,6 +15,7 @@ using Kbg.NppPluginNET.PluginInfrastructure;
 using NppPluginNET;
 using static Kbg.NppPluginNET.PluginInfrastructure.Win32;
 using System.Diagnostics;
+using System.Runtime;
 
 namespace Kbg.NppPluginNET
 {
@@ -74,6 +75,10 @@ namespace Kbg.NppPluginNET
                     frmNavigateTo.ReloadFileList();
                     frmNavigateTo.FilterDataGrid("");
                     break;
+                // the editor color scheme changed, so update form colors
+                case (uint)NppMsg.NPPN_WORDSTYLESUPDATED:
+                    NavigateTo.Plugin.Namespace.Main.RestyleEverything();
+                    return;
             }
         }
 
@@ -103,7 +108,7 @@ namespace NavigateTo.Plugin.Namespace
         static Icon tbIcon = null;
 
         public static IScintillaGateway editor = new ScintillaGateway(PluginBase.GetCurrentScintilla());
-        static INotepadPPGateway notepad = new NotepadPPGateway();
+        public static INotepadPPGateway notepad = new NotepadPPGateway();
         public static FrmNavigateTo frmNavigateTo = null;
         public static FrmSettings frmSettings = new FrmSettings(editor, notepad);
         public static bool isShuttingDown = false;
@@ -230,5 +235,19 @@ namespace NavigateTo.Plugin.Namespace
         }
 
         #endregion
+
+        /// <summary>
+        /// Apply the appropriate styling
+        /// (either generic control styling or Notepad++ styling as the case may be)
+        /// to all forms.
+        /// </summary>
+        public static void RestyleEverything()
+        {
+            bool isDark = notepad.IsDarkModeEnabled();
+            if (frmNavigateTo != null && !frmNavigateTo.IsDisposed)
+                FormStyle.ApplyStyle(frmNavigateTo, true, isDark);
+            if (frmSettings != null && !frmSettings.IsDisposed)
+                FormStyle.ApplyStyle(frmSettings, true, isDark);
+        }
     }
 }

--- a/NppNavigateTo/NppNavigateTo.csproj
+++ b/NppNavigateTo/NppNavigateTo.csproj
@@ -73,6 +73,7 @@
       <DependentUpon>AboutForm.cs</DependentUpon>
     </Compile>
     <Compile Include="PluginInfrastructure\ClikeStringArray.cs" />
+    <Compile Include="PluginInfrastructure\DarkMode.cs" />
     <Compile Include="PluginInfrastructure\DllExport\DllExportAttribute.cs">
       <Link>PluginInfrastructure\DllExport\DllExportAttribute.cs</Link>
     </Compile>
@@ -161,6 +162,7 @@
     </Compile>
     <Compile Include="SearchUtils.cs" />
     <Compile Include="Settings.cs" />
+    <Compile Include="FormStyle.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/NppNavigateTo/PluginInfrastructure/DarkMode.cs
+++ b/NppNavigateTo/PluginInfrastructure/DarkMode.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace Kbg.NppPluginNET.PluginInfrastructure
+{
+    /// <summary>
+    /// Holds the BGR values of the active dark mode theme.
+    /// <see href "https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/src/NppDarkMode.h"/>
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DarkModeColors
+    {
+        public int Background;
+        public int SofterBackground;
+        public int HotBackground;
+        public int PureBackground;
+        public int ErrorBackground;
+        public int Text;
+        public int DarkerText;
+        public int DisabledText;
+        public int LinkText;
+        public int Edge;
+        public int HotEdge;
+        public int DisabledEdge;
+    }
+
+    /// <summary>
+    /// Extends <see cref="NotepadPPGateway"/> with methods implementing Npp's dark mode API.
+    /// </summary>
+    public partial class NotepadPPGateway : INotepadPPGateway
+    {
+        public IntPtr GetDarkModeColors()
+        {
+            DarkModeColors darkModeColors = new DarkModeColors();
+            IntPtr _cbSize = new IntPtr(Marshal.SizeOf(darkModeColors));
+            IntPtr _ptrDarkModeColors = Marshal.AllocHGlobal(_cbSize);
+            Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_GETDARKMODECOLORS, _cbSize, _ptrDarkModeColors);
+            return _ptrDarkModeColors;
+        }
+
+        public bool IsDarkModeEnabled()
+        {
+            IntPtr result = Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_ISDARKMODEENABLED, Unused, Unused);
+            return ((int)result == 1);
+        }
+    }
+
+    static class NppDarkMode
+    {
+        public static Color BGRToColor(int bgr)
+        {
+            return Color.FromArgb((bgr & 0xFF), ((bgr >> 8) & 0xFF), ((bgr >> 16) & 0xFF));
+        }
+    }
+}

--- a/NppNavigateTo/PluginInfrastructure/Msgs_h.cs
+++ b/NppNavigateTo/PluginInfrastructure/Msgs_h.cs
@@ -560,6 +560,21 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// </summary>
         NPPM_ADDTOOLBARICON_FORDARKMODE = Constants.NPPMSG + 101,
 
+        /// <summary>
+        /// bool NPPM_ISDARKMODEENABLED(0, 0)
+        /// Returns true when Notepad++ Dark Mode is enabled, false when it is not.
+        /// <see href="https://github.com/notepad-plus-plus/notepad-plus-plus/commit/1eb5b10e41d7ab92b60aa32b28d4fe7739d15b53"/>
+        /// </summary>
+        NPPM_ISDARKMODEENABLED = (Constants.NPPMSG + 107),
+
+        /// <summary>
+        /// bool NPPM_GETDARKMODECOLORS (size_t cbSize, NppDarkMode::Colors* returnColors)
+        /// - cbSize must be filled with sizeof(NppDarkMode::Colors).
+        /// - returnColors must be a pre-allocated NppDarkMode::Colors struct.
+        /// Returns true when successful, false otherwise.
+        /// </summary>
+        NPPM_GETDARKMODECOLORS = (Constants.NPPMSG + 108),
+
         RUNCOMMAND_USER = Constants.WM_USER + 3000,
         NPPM_GETFULLCURRENTPATH = RUNCOMMAND_USER + FULL_CURRENT_PATH,
         NPPM_GETCURRENTDIRECTORY = RUNCOMMAND_USER + CURRENT_DIRECTORY,

--- a/NppNavigateTo/PluginInfrastructure/NotepadPPGateway.cs
+++ b/NppNavigateTo/PluginInfrastructure/NotepadPPGateway.cs
@@ -29,15 +29,19 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         bool SwitchToFile(string path, bool isTab);
         Dictionary<NppMenuCmd, string> MainMenuItems { get; set; }
         string ReloadMenuItems();
-
         int getCurrentView();
+        int[] GetNppVersion();
+        Color GetDefaultForegroundColor();
+        Color GetDefaultBackgroundColor();
+        bool IsDarkModeEnabled();
+        IntPtr GetDarkModeColors();
     }
 
     /// <summary>
     /// This class holds helpers for sending messages defined in the Msgs_h.cs file. It is at the moment
     /// incomplete. Please help fill in the blanks.
     /// </summary>
-    public class NotepadPPGateway : INotepadPPGateway
+    public partial class NotepadPPGateway : INotepadPPGateway
     {
         private const int Unused = 0;
 
@@ -205,6 +209,32 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         {
             Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_SETCURRENTLANGTYPE, Unused,
                 (int)language);
+        }
+
+        /// <summary>
+		/// 3-int array: {major, minor, bugfix}<br></br>
+		/// Thus GetNppVersion() would return {8, 5, 0} for version 8.5.0
+		/// and {7, 7, 1} for version 7.7.1
+		/// </summary>
+		/// <returns></returns>
+		public int[] GetNppVersion()
+        {
+            int version = Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_GETNPPVERSION, 0, 0).ToInt32();
+            int major = version >> 16;
+            int minor = Math.DivRem(version & 0xffff, 10, out int bugfix);
+            return new int[] { major, minor, bugfix };
+        }
+
+        public Color GetDefaultForegroundColor()
+        {
+            var rawColor = (int)Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_GETEDITORDEFAULTFOREGROUNDCOLOR, 0, 0);
+            return Color.FromArgb(rawColor & 0xff, (rawColor >> 8) & 0xff, (rawColor >> 16) & 0xff);
+        }
+
+        public Color GetDefaultBackgroundColor()
+        {
+            var rawColor = (int)Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_GETEDITORDEFAULTBACKGROUNDCOLOR, 0, 0);
+            return Color.FromArgb(rawColor & 0xff, (rawColor >> 8) & 0xff, (rawColor >> 16) & 0xff);
         }
     }
 


### PR DESCRIPTION
1. All forms will now be colored to match the Notepad++ theme. This is true in dark mode and also with non-dark-mode themes that the user might use (e.g., Vim Dark Blue, Blackboard). However, the background of the DataGridView containing the filename rows is bugged in a very weird way. Hopefully someone can figure that out.
![image](https://github.com/young-developer/nppNavigateTo/assets/46202915/c0d3b3b5-7319-412b-a9c4-7559f065fb6b)
2. Added a system for checking if the current directory is very large and could potentially cause tremendously long latency when the user has chosen recursive subdirectory search. Now a warning will pop up if there are more than 5000 files in the current directory tree, so that the user can choose to search only the top directory, or not to search that dir at all.
![image](https://github.com/young-developer/nppNavigateTo/assets/46202915/93ca2d90-9ac2-43ee-90bc-b99fe61fdd20)
