### PR TITLE
Fix directory search bugs from last PR

### DIFF
--- a/NppNavigateTo/Forms/FrmNavigateTo.cs
+++ b/NppNavigateTo/Forms/FrmNavigateTo.cs
@@ -175,8 +175,11 @@ namespace NavigateTo.Plugin.Namespace
                 : DirectorySearchLevel.TopDirOnly;
             long nextTimeToRefresh = 0;
             if (!shouldReloadFiles &&
-                lastReloadTimes.TryGetValue(currentDirectory, out long nextRefresh))
-                nextTimeToRefresh = nextRefresh;
+                lastReloadTimes.TryGetValue(currentDirectory, out long lastReload))
+            {
+                long delayBetweenReloads = FrmSettings.Settings.GetIntSetting(Settings.secondsBetweenDirectoryScans) * 10_000_000L; // 10 million ticks per second
+                nextTimeToRefresh = lastReload + delayBetweenReloads;
+            }
             DirectorySearchLevel searchLevelOverride = searchLevel;
             if (searchLevelOverrides.TryGetValue(currentDirectory, out var searchOverride))
                 searchLevelOverride = searchOverride;

--- a/NppNavigateTo/Forms/FrmSettings.cs
+++ b/NppNavigateTo/Forms/FrmSettings.cs
@@ -99,12 +99,22 @@ namespace NavigateTo.Plugin.Namespace
 
         private void checkBox1_CheckedChanged(object sender, EventArgs e)
         {
+            if (Main.frmNavigateTo != null)
+                Main.frmNavigateTo.shouldReloadFiles = true;
+            bool isChecked = checkBoxSearchInFolder.Checked;
+            if (!isChecked)
+                checkBoxSearchInSubDirs.Checked = false;
             Settings.SetBoolSetting(Settings.searchInCurrentFolder, checkBoxSearchInFolder.Checked);
         }
 
         private void checkBox1_CheckedChanged_1(object sender, EventArgs e)
         {
-            Settings.SetBoolSetting(Settings.searchInSubDirs, checkBoxSearchInSubDirs.Checked);
+            if (Main.frmNavigateTo != null)
+                Main.frmNavigateTo.shouldReloadFiles = true;
+            bool isChecked = checkBoxSearchInSubDirs.Checked;
+            if (isChecked)
+                checkBoxSearchInFolder.Checked = true;
+            Settings.SetBoolSetting(Settings.searchInSubDirs, isChecked);
         }
 
         private void buttonHighlightColor_Click(object sender, EventArgs e)

--- a/NppNavigateTo/NppNavigateTo.cs
+++ b/NppNavigateTo/NppNavigateTo.cs
@@ -65,13 +65,16 @@ namespace Kbg.NppPluginNET
                     // this makes the editor track the current instance.
                     NavigateTo.Plugin.Namespace.Main.editor = new ScintillaGateway(PluginBase.GetCurrentScintilla());
                     var frmNavigateTo = NavigateTo.Plugin.Namespace.Main.frmNavigateTo;
-                    if (frmNavigateTo == null || NavigateTo.Plugin.Namespace.Main.isShuttingDown)
-                        // a bunch of NPPN_BUFFERACTIVATED events fire when Notepad++ is shutting down
-                        // which will lead to this being called repeatedly
+                    if (frmNavigateTo == null || !frmNavigateTo.Visible
+                        || NavigateTo.Plugin.Namespace.Main.isShuttingDown)
+                        // DO NOT reload file list if:
+                        // 1. Notepad++ is shutting down
+                        // 2. NavigateTo form doesn't exist or is not visible
                         return;
-                    frmNavigateTo.shouldReloadFilesInDirectory = notification.Header.Code == (uint)NppMsg.NPPN_BUFFERACTIVATED;
-                    if (!frmNavigateTo.Visible)
-                        return;
+                    // reload the file list whenever you open a file in a different directory
+                    if (frmNavigateTo.currentDirectory == null ||
+                        frmNavigateTo.currentDirectory != NavigateTo.Plugin.Namespace.Main.notepad.GetCurrentFileDirectory())
+                        frmNavigateTo.shouldReloadFiles = true;
                     frmNavigateTo.ReloadFileList();
                     frmNavigateTo.FilterDataGrid("");
                     break;


### PR DESCRIPTION
1. Fix bug (introduced by previous commit)
   where searching the top directory only led to
   an uncaught error.
2. Do not trigger a directory search when opening
    a file in the same directory as the previously open file.
3. Require that the button to allow subdirectory search
    can only be checked if and only if
    the button to allow top directory search is also checked.
4. Always trigger a directory refresh when directory search
    when settings are changed.