### PR TITLE
fix dark mode header color; settings not topmost

### DIFF
--- a/NppNavigateTo/FormStyle.cs
+++ b/NppNavigateTo/FormStyle.cs
@@ -89,9 +89,12 @@ namespace NavigateTo.Plugin.Namespace
                         // when you first open the form in dark mode.
                         // The background is untouched by the current style until you change to another style and then back,
                         // at which point the background remembers what color it's supposed to be. Very odd.
+                        dgv.EnableHeadersVisualStyles = false;
                         dgv.BackgroundColor = InBetween;
                         dgv.ForeColor = NppDarkMode.BGRToColor(textTheme);
                         dgv.GridColor = NppDarkMode.BGRToColor(theme.HotBackground);
+                        dgv.ColumnHeadersDefaultCellStyle.ForeColor = NppDarkMode.BGRToColor(textTheme);
+                        dgv.ColumnHeadersDefaultCellStyle.BackColor = NppDarkMode.BGRToColor(theme.PureBackground);
                         dgv.RowHeadersDefaultCellStyle.ForeColor = NppDarkMode.BGRToColor(textTheme);
                         dgv.RowHeadersDefaultCellStyle.BackColor = NppDarkMode.BGRToColor(theme.PureBackground);
                         dgv.RowsDefaultCellStyle.ForeColor = NppDarkMode.BGRToColor(textTheme);
@@ -135,6 +138,7 @@ namespace NavigateTo.Plugin.Namespace
                     }
                     else if (child is DataGridView dgv)
                     {
+                        dgv.EnableHeadersVisualStyles = true;
                         dgv.BackgroundColor = SystemColors.ControlDark;
                         dgv.ForeColor = SystemColors.ControlText;
                         dgv.GridColor = SystemColors.ControlDarkDark;
@@ -166,9 +170,12 @@ namespace NavigateTo.Plugin.Namespace
                 }
                 else if (child is DataGridView dgv)
                 {
+                    dgv.EnableHeadersVisualStyles = false;
                     dgv.BackgroundColor = InBetween;
                     dgv.ForeColor = foreColor;
                     dgv.GridColor = foreColor;
+                    dgv.ColumnHeadersDefaultCellStyle.ForeColor = foreColor;
+                    dgv.ColumnHeadersDefaultCellStyle.BackColor = backColor;
                     dgv.RowHeadersDefaultCellStyle.ForeColor = foreColor;
                     dgv.RowHeadersDefaultCellStyle.BackColor = backColor;
                     dgv.RowsDefaultCellStyle.ForeColor = foreColor;

--- a/NppNavigateTo/Forms/FrmSettings.designer.cs
+++ b/NppNavigateTo/Forms/FrmSettings.designer.cs
@@ -595,7 +595,6 @@
             this.Name = "FrmSettings";
             this.ShowIcon = false;
             this.Text = "Navigate To - Settings";
-            this.TopMost = true;
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.frmSettings_FormClosing);
             this.Load += new System.EventHandler(this.frmSettings_Load);
             this.Shown += new System.EventHandler(this.frmSettings_Shown);


### PR DESCRIPTION
Previously header rows and the row header column did not have the same coloring as the rest of the data grid when applying dark mode or another theme. This has been fixed.

I also made the settings form not topmost, because I didn't like how it got in the way of pop-up messages (e.g., the message that asks if you want to scan the whole directory tree) and the navigation form. It will still display on top when focused, as normal.