### PR TITLE
add support for glob syntax, address issue 50

### DIFF
--- a/NppNavigateTo/Forms/AboutForm.cs
+++ b/NppNavigateTo/Forms/AboutForm.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Windows.Forms;
+using NppPluginNET;
 
 namespace NavigateTo.Plugin.Namespace
 {
@@ -16,7 +17,7 @@ namespace NavigateTo.Plugin.Namespace
         public AboutForm()
         {
             InitializeComponent();
-            Title.Text = $"NavigateTo v{AssemblyVersionString()}";
+            Title.Text = $"NavigateTo v{MiscUtils.AssemblyVersionString()}";
             FormStyle.ApplyStyle(this, true, Main.notepad.IsDarkModeEnabled());
         }
 
@@ -42,14 +43,6 @@ namespace NavigateTo.Plugin.Namespace
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
             }
-        }
-
-        public static string AssemblyVersionString()
-        {
-            string version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-            while (version.EndsWith(".0"))
-                version = version.Substring(0, version.Length - 2);
-            return version;
         }
 
         /// <summary>

--- a/NppNavigateTo/Glob.cs
+++ b/NppNavigateTo/Glob.cs
@@ -1,0 +1,271 @@
+﻿using Kbg.NppPluginNET.PluginInfrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Windows.Forms;
+
+namespace NavigateTo.Plugin.Namespace
+{
+    public enum Ternary
+    {
+        FALSE,
+        TRUE,
+        UNDECIDED,
+    }
+
+    public class GlobFunction
+    {
+        public Func<string, bool> Matcher { get; }
+        public bool Or { get; }
+        public bool Negated { get; }
+
+        public GlobFunction(Func<string, bool> matcher, bool or, bool negated)
+        {
+            this.Matcher = matcher;
+            this.Or = or;
+            this.Negated = negated;
+        }
+
+        public Ternary IsMatch(string inp, Ternary previousResult)
+        {
+            if (Or && (previousResult == Ternary.TRUE))
+                return Ternary.TRUE;
+            if (!Or && (previousResult == Ternary.FALSE))
+                return Ternary.FALSE;
+            bool result = Matcher(inp);
+            return (result ^ Negated) ? Ternary.TRUE : Ternary.FALSE;
+        }
+    }
+
+    /// <summary>
+    /// parser that parses glob syntax in space-separated globs<br></br>
+    /// 1. Default behavior is to match ALL space-separated globs
+    ///     (e.g. "foo bar txt" matches "foobar.txt" and "bartxt.foo")<br></br>
+    /// 2. Also use glob syntax:<br></br>
+    ///     * "*" matches any number (incl. zero) of characters except "\\"<br></br>
+    ///     * "**" matches any number (incl. zero) of characters including "\\"<br></br>
+    ///     * "[chars]" matches all characters inside the square brackets (same as in Perl-style regex, also includes character classes like [a-z], [0-9]). Note: can match ' ', which is normally a glob separator<br></br>
+    ///     * "[!chars]" matches NONE of the characters inside the square brackets (and also doesn't match "\\") (same as Perl-style "[^chars]")<br></br>
+    ///     * "foo.{abc,def,hij}" matches "foo.abc", "foo.def", or "foo.hij". Essentially "{x,y,z}" is equivalent to "(?:x|y|z)" in Perl-style regex<br></br>
+    ///     * "?" matches any one character except "\\"<br></br>
+    /// 3. "foo | bar" matches foo OR bar ("|" implements logical OR)<br></br>
+    /// 4. "!foo" matches anything that DOES NOT CONTAIN "foo"<br></br>
+    /// 5. "foo | &lt;baz bar&gt;" matches foo OR (bar AND baz) (that is, "&lt;" and "&gt;" act as grouping parentheses)
+    /// </summary>
+    public class Glob
+    {
+        public int ii;
+        public string ErrorMsg;
+        public int ErrorPos;
+        public List<string> globs;
+
+        public Glob()
+        {
+            globs = new List<string>();
+            Reset();
+        }
+
+        public void Reset()
+        {
+            globs.Clear();
+            ErrorMsg = null;
+            ErrorPos = -1;
+            ii = 0;
+        }
+
+        public char Peek(string inp)
+        {
+            return (ii < inp.Length - 1)
+                ? inp[ii + 1]
+                : '\x00';
+        }
+
+        public Regex Glob2Regex(string inp)
+        {
+            var sb = new StringBuilder();
+            int start = ii;
+            bool is_char_class = false;
+            bool uses_metacharacters = false;
+            bool is_alternation = false;
+            while (ii < inp.Length)
+            {
+                char c = inp[ii];
+                char next_c;
+                switch (c)
+                {
+                case '/': sb.Append("\\\\"); break;
+                case '\\':
+                    next_c = Peek(inp);
+                    if (next_c == 'x' || next_c == 'u' // \xNN, \uNNNN unicode escapes
+                        || (next_c == ']' && is_char_class))
+                        sb.Append('\\'); 
+                    else
+                        sb.Append("\\\\");
+                    break;
+                case '*':
+                    if (is_char_class)
+                    {
+                        sb.Append("\\*"); // "[*]" matches literal * character
+                        break;
+                    }
+                    else if (sb.Length == 0)
+                        break; // since globs are only anchored at the end,
+                               // leading * in globs should not influence the matching behavior.
+                               // For example, the globs "*foo.txt" and "foo.txt" should match the same things.
+                    uses_metacharacters = true;
+                    next_c = Peek(inp);
+                    if (next_c == '*')
+                    {
+                        ii++;
+                        // "**" means recursive search; ignores path delimiters
+                        sb.Append(".*");
+                    }
+                    else
+                    {
+                        // "*" means anything but a path delimiter
+                        sb.Append(@"[^\\]*");
+                    }
+                    break;
+                case '[':
+                    uses_metacharacters = true;
+                    sb.Append('[');
+                    next_c = Peek(inp);
+                    if (!is_char_class && next_c == '!')
+                    {
+                        sb.Append("^\\\\"); // [! begins a negated char class, but also need to exclude path sep
+                        ii++;
+                    }
+                    is_char_class = true;
+                    break;
+                case ']':
+                    is_char_class = false;
+                    sb.Append(']');
+                    break; // TODO: consider allowing nested [] inside char class
+                case '{':
+                    if (is_char_class)
+                        sb.Append("\\{");
+                    else
+                    {
+                        uses_metacharacters = true;
+                        is_alternation = true; // e.g. *.{cpp,h,c} matches *.cpp or *.h or *.c
+                        sb.Append("(?:");
+                    }
+                    break;
+                case '}':
+                    if (is_char_class)
+                        sb.Append("\\}");
+                    else
+                    {
+                        sb.Append(")");
+                        is_alternation = false;
+                    }
+                    break;
+                case ',':
+                    if (is_alternation)
+                        sb.Append('|'); // e.g. *.{cpp,h,c} matches *.cpp or *.h or *.c
+                    else
+                        sb.Append(',');
+                    break;
+                case '.': case '$': case '(': case ')': case '^':
+                    // these chars have no special meaning in glob syntax, but they're regex metacharacters
+                    sb.Append('\\');
+                    sb.Append(c);
+                    break;
+                case '?':
+                    if (is_char_class)
+                        sb.Append('?');
+                    else
+                    {
+                        uses_metacharacters = true;
+                        sb.Append(@"[^\\]"); // '?' is any single char
+                    }
+                    break;
+                case '|': case '<': case '>': case ';': case '\t':
+                    goto endOfLoop; // these characters are never allowed in Windows paths
+                case ' ': case '!':
+                    if (is_char_class)
+                        sb.Append(c);
+                    else
+                        goto endOfLoop; // allow ' ' and '!' inside char classes, but otherwise these are special chars in NavigateTo
+                    break;
+                default:
+                    sb.Append(c);
+                    break;
+                }
+                ii++;
+            }
+            endOfLoop:
+            if (uses_metacharacters) // anything without "*" or "?" or "[]" or 
+                sb.Append('$'); // globs are anchored at the end; that is "*foo" does not match "foo/bar.txt" but "*foo.tx?" does
+            string pat = sb.ToString();
+            try
+            {
+                var regex = new Regex(pat, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                globs.Add(pat);
+                return regex;
+            }
+            catch (Exception ex)
+            {
+                ErrorMsg = ex.Message;
+                ErrorPos = start;
+                return null;
+            }
+        }
+
+        public Func<string, bool> Parse(string inp, bool fromBeginning = true)
+        {
+            if (fromBeginning)
+                Reset();
+            bool or = false;
+            bool negated = false;
+            var globFuncs = new List<GlobFunction>();
+            while (ii < inp.Length)
+            {
+                char c = inp[ii];
+                if (c == ' ' || c == '\t' || c == ';') { }
+                else if (c == '|')
+                    or = true;
+                else if (c == '!')
+                    negated = !negated;
+                else if (c == '<')
+                {
+                    ii++;
+                    var subFunc = Parse(inp, false);
+                    globFuncs.Add(new GlobFunction(subFunc, or, negated));
+                    negated = false;
+                    or = false;
+                }
+                else if (c == '>')
+                    break;
+                else
+                {
+                    var globRegex = Glob2Regex(inp);
+                    if (globRegex == null)
+                        continue; // ignore errors, try to parse everything else
+                    globFuncs.Add(new GlobFunction(globRegex.IsMatch, or, negated));
+                    ii--;
+                    negated = false;
+                    or = false;
+                }
+                ii++;
+            }
+            ii++;
+            if (globFuncs.All(gf => !gf.Or))
+                // return a more efficient function that short-circuits
+                // if none of the GlobFunctions use logical or
+                return (string x) => globFuncs.All(gf => gf.Matcher(x) ^ gf.Negated);
+            bool finalFunc(string x)
+            {
+                Ternary result = Ternary.UNDECIDED;
+                foreach (GlobFunction globFunc in globFuncs)
+                {
+                    result = globFunc.IsMatch(x, result);
+                }
+                return result != Ternary.FALSE;
+            }
+            return finalFunc;
+        }
+    }
+}

--- a/NppNavigateTo/MiscUtils.cs
+++ b/NppNavigateTo/MiscUtils.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+using System.Windows.Forms;
+using Kbg.NppPluginNET.PluginInfrastructure;
+
+namespace NppPluginNET
+{
+    /// <summary>
+    /// contains connectors to Scintilla (editor) and Notepad++ (notepad)
+    /// and miscellaneous other helper functions
+    /// </summary>
+    public class MiscUtils
+    {
+        /// <summary>
+        /// connector to Scintilla
+        /// </summary>
+        public static IScintillaGateway editor = NavigateTo.Plugin.Namespace.Main.editor;
+        /// <summary>
+        /// connector to Notepad++
+        /// </summary>
+        public static INotepadPPGateway notepad = NavigateTo.Plugin.Namespace.Main.notepad;
+
+        /// <summary>
+        /// append text to current doc, then append newline and move cursor
+        /// </summary>
+        /// <param name="inp"></param>
+        public static void AddLine(string inp)
+        {
+            editor.AppendText(Encoding.UTF8.GetByteCount(inp), inp);
+            editor.AppendText(Environment.NewLine.Length, Environment.NewLine);
+        }
+
+        /// <summary>
+        /// input is one of 'p', 'd', 'f'<br></br>
+        /// if 'p', get full path to current file (default)<br></br>
+        /// if 'd', get directory of current file<br></br>
+        /// if 'f', get filename of current file
+        /// </summary>
+        /// <param name="which"></param>
+        /// <returns></returns>
+        public static string GetCurrentPath(char which = 'p')
+        {
+            NppMsg msg = NppMsg.NPPM_GETFULLCURRENTPATH;
+            switch (which)
+            {
+            case 'p': break;
+            case 'd': msg = NppMsg.NPPM_GETCURRENTDIRECTORY; break;
+            case 'f': msg = NppMsg.NPPM_GETFILENAME; break;
+            default: throw new ArgumentException("GetCurrentPath argument must be one of 'p', 'd', 'f'");
+            }
+
+            StringBuilder path = new StringBuilder(Win32.MAX_PATH);
+            Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)msg, 0, path);
+
+            return path.ToString();
+        }
+
+        /// <summary>
+        /// Trying to copy an empty string or null to the clipboard raises an error.<br></br>
+        /// This shows a message box if the user tries to do that.
+        /// </summary>
+        /// <param name="text"></param>
+        public static void TryCopyToClipboard(string text)
+        {
+            if (text == null || text.Length == 0)
+            {
+                MessageBox.Show("Couldn't find anything to copy to the clipboard",
+                    "Nothing to copy to clipboard",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning
+                );
+                return;
+            }
+            Clipboard.SetText(text);
+        }
+
+        public static string AssemblyVersionString()
+        {
+            string version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            while (version.EndsWith(".0"))
+                version = version.Substring(0, version.Length - 2);
+            return version;
+        }
+    }
+}

--- a/NppNavigateTo/NppNavigateTo.cs
+++ b/NppNavigateTo/NppNavigateTo.cs
@@ -11,6 +11,7 @@ using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using NavigateTo.Plugin.Namespace;
+using NavigateTo.Tests;
 using Kbg.NppPluginNET.PluginInfrastructure;
 using NppPluginNET;
 using static Kbg.NppPluginNET.PluginInfrastructure.Win32;
@@ -128,6 +129,7 @@ namespace NavigateTo.Plugin.Namespace
             PluginBase.SetCommand(2, "---", null);
             PluginBase.SetCommand(3, "A&bout", ShowAboutForm);
             PluginBase.SetCommand(4, "Check &updates", OpenReleasePage);
+            PluginBase.SetCommand(5, "Run &tests", TestRunner.RunAll);
         }
 
         static internal void SetToolBarIcon()

--- a/NppNavigateTo/NppNavigateTo.csproj
+++ b/NppNavigateTo/NppNavigateTo.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Forms\AboutForm.Designer.cs">
       <DependentUpon>AboutForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="Glob.cs" />
     <Compile Include="PluginInfrastructure\ClikeStringArray.cs" />
     <Compile Include="PluginInfrastructure\DarkMode.cs" />
     <Compile Include="PluginInfrastructure\DllExport\DllExportAttribute.cs">
@@ -163,6 +164,9 @@
     <Compile Include="SearchUtils.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="FormStyle.cs" />
+    <Compile Include="Tests\GlobTester.cs" />
+    <Compile Include="MiscUtils.cs" />
+    <Compile Include="Tests\TestRunner.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/NppNavigateTo/Tests/GlobTester.cs
+++ b/NppNavigateTo/Tests/GlobTester.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NavigateTo.Plugin.Namespace;
+using NppPluginNET;
+
+namespace NavigateTo.Tests
+{
+    public class GlobTester
+    {
+        public static void Test()
+        {
+            int ii = 0;
+            int failed = 0;
+            var testcases = new (string query, (string input, bool desiredResult)[])[]
+            {
+                ("foo bar", new[]
+                {
+                    ("foobar.txt", true),
+                    ("bar.foo", true),
+                    ("bar.txt", false),
+                    ("foo.txt", false),
+                }),
+                ("foo bar txt", new[]
+                {
+                    ("foobar.txt", true),
+                    ("bar.foo", false),
+                    ("bar.txt", false),
+                    ("foo.txt", false),
+                }),
+                ("foo;bar;*.txt", new[]
+                {
+                    ("foobar.txt", true),
+                    ("bar.foo", false),
+                    ("bar.txt", false),
+                    ("foo.txt", false),
+                }),
+                ("foo | bar", new[]
+                {
+                    ("foobar.txt", true),
+                    ("bar.txt", true),
+                    ("foo.txt", true),
+                    ("ghi.txt", false),
+                }),
+                ("!bar", new[]
+                {
+                    ("foo.txt", true),
+                    ("bar.txt", false),
+                }),
+                ("foo !bar", new[]
+                {
+                    ("foobar.txt", false),
+                    ("foo.txt", true),
+                    ("ghi.txt", false),
+                }),
+                ("foo | < !bar baz", new[]
+                {
+                    ("foo.bar", true),
+                    ("bar.baz", false),
+                    ("baz.txt", true),
+                    ("foo.baz", true),
+                }),
+                ("foo**[!c-p]uack*.{tx?,cpp} !fgh | <bar baz", new[]
+                {
+                    ("foo\\boo\\quacked.txt", true),
+                    ("foo\\boo\\quacked.cpp", true),
+                    ("foozuack.txb", true),
+                    ("bar.baz", true),
+                    ("baz.bar", true),
+                    ("fgh\\bar.baz", true),
+                    ("foo\\boo\\duacked.txt", false),
+                    ("foo\\boo\\uacked.txt", false),
+                    ("foozuack.xml", false),
+                    ("foo.baz", false),
+                    ("foo\\boo\\quacked.txto", false),
+                    ("foo\\fgh\\quacked.txt", false),
+                    ("foo\\fgh\\quacked.cpp", false),
+                    ("foo\\boo\\quacked\\bad.txt", false),
+                }),
+                ("foo[ !]*.*", new[]
+                {
+                    ("foo!man.txt", true),
+                    ("foo man.txt", true),
+                    ("footman.txt", false),
+                    ("C:\\reoreno\\84303\\foo .eorn", true),
+                    ("foo!.zzy", true),
+                }),
+                ("foo[! ].*", new[]
+                {
+                    ("foot.txt", true),
+                    ("foo .txt", false),
+                    ("boot.txt", false),
+                    ("foo\\.txt", false),
+                }),
+                ("**!bar", new[]
+                {
+                    ("", true),
+                    ("reore", true),
+                    ("$#@.~~~", true),
+                    ("bar.txt", false),
+                }),
+                ("foo|bar!baz", new[]
+                {
+                    ("bar.txt", true),
+                    ("foo.txt", true),
+                    ("foo.baz", false),
+                    ("bar.baz", false),
+                }),
+                ("^.()[[ ]]$.*", new[]
+                {
+                    ("^.()[]$.xml", true),
+                    ("^.() ]$.xml", true),
+                    ("^.()]]$.xml", false),
+                    ("foo.xml", false),
+                }),
+                ("*[*].{h,c[px][px]}", new[]
+                {
+                    ("foo*.h", true),
+                    ("bar*.cpp", true),
+                    ("baz*.cpx", true),
+                    ("foo\\qux*.cxp", true),
+                    ("roeu\\843*.cxx", true),
+                    ("roeu\\843*.c\\x", false),
+                    ("foo\\qux.cxp", false),
+                    ("foo.h", false),
+                    ("roeu\\843*.cxxe", false),
+                    ("roeu\\843*.xxx", false),
+                    ("843.cxx", false),
+                }),
+                ("{foo,bar}.{txt,md}", new[]
+                {
+                    ("foo.txt", true),
+                    ("foo.md", true),
+                    ("bar.txt", true),
+                    ("bar.md", true),
+                    ("bar.baz", false),
+                }),
+                ("foo{ baz bar[", new[] // test ignoring of globs with syntactically invalid globs
+                {
+                    ("baz.txt", true),
+                    ("foo.txt", false),
+                }),
+                ("baz *.foo{1,2} bar{", new[]
+                {
+                    ("baz.foo1", true),
+                    ("c:\\bazel.foo2", true),
+                    ("baz\\fjie.foo1", true),
+                    ("baz\\fjie\\foo3", false),
+                    ("baz\\fjie\\foo1", false),
+                    ("bazfjie.foo3", false),
+                    ("baz\\fjie\\foo12", false),
+                }),
+                ("\\x20\\x21a\\u0434.txt", new[] // " !aд", check support for \xNN, \uNNNN
+                {
+                    (" !aд.txt", true),
+                    ("foo\\ !aд.txt", true),
+                    ("!aд.txt", false),
+                    ("aд.txt", false),
+                    ("д.md", false),
+                }),
+            };
+            var glob = new Glob();
+            foreach ((string query, var examples) in testcases)
+            {
+                Func<string, bool> resultFunc;
+                try
+                {
+                    resultFunc = glob.Parse(query);
+                }
+                catch (Exception ex)
+                {
+                    ii++;
+                    MiscUtils.AddLine($"While parsing query \"{query}\", got exception\r\n{ex}");
+                    failed++;
+                    continue;
+                }
+                foreach ((string filename, bool desiredResult) in examples)
+                {
+                    ii++;
+                    bool result;
+                    try
+                    {
+                        result = resultFunc(filename);
+                    }
+                    catch (Exception ex)
+                    {
+                        MiscUtils.AddLine($"While executing query \"{query}\" on filename \"{filename}\", got exception\r\n{ex}");
+                        failed++;
+                        continue;
+                    }
+                    if (result != desiredResult)
+                    {
+                        MiscUtils.AddLine($"Running query \"{query}\" on filename \"{filename}\", EXPECTED {desiredResult}, GOT {result}");
+                        failed++;
+                        continue;
+                    }
+                }
+            }
+            MiscUtils.AddLine($"Ran {ii} tests and failed {failed}");
+        }
+    }
+}

--- a/NppNavigateTo/Tests/TestRunner.cs
+++ b/NppNavigateTo/Tests/TestRunner.cs
@@ -1,0 +1,23 @@
+﻿/*
+A test runner for all of this package.
+*/
+using System.Threading.Tasks;
+using NppPluginNET;
+
+namespace NavigateTo.Tests
+{
+    public class TestRunner
+    {
+        public static void RunAll()
+        {
+            MiscUtils.notepad.FileNew();
+            MiscUtils.AddLine($"Test results for NavigateTo v{MiscUtils.AssemblyVersionString()}");
+
+            MiscUtils.AddLine(@"=========================
+Testing Glob syntax
+=========================
+");
+            GlobTester.Test();
+        }
+    }
+}

--- a/test_results.txt
+++ b/test_results.txt
@@ -1,0 +1,6 @@
+Test results for NavigateTo v2.5.4
+=========================
+Testing Glob syntax
+=========================
+
+Ran 90 tests and failed 0


### PR DESCRIPTION
See documentation for Glob class in Glob.cs. Would implement #50.
Note that this is fully backwards-compatible with existing non-fuzzy matching, so it is unnecessary to add a new setting.

Moved some helper functions to MiscUtils.cs (needed for re-use in GlobTester.cs and TestRunner.cs)

Rearranged code in NppNavigateTo.cs in an order that more closely parallels the order in which it is first referenced. Most of the diff in that file is just moving stuff around, and most of the remaining diff is due to the introduction of glob syntax.

Also started to add code for a background worker; it's all commented out now.
I may eventually consider offloading some work to a background worker but currently it doesn't seem super necessary. It is only helpful when dealing with many thousands of files (based on testing with roughly 59k files), but it could be critical in that case for preventing NavigateTo from locking up Notepad++.

This does not appear to break any existing functionality, although I've never *really* understood how the fuzzy matching is supposed to work so I wouldn't necessarily know if the fuzzy matching wasn't working quite as intended.