### PR TITLE
Add docs for new glob syntax, fix minor glob bug

### DIFF
--- a/NppNavigateTo/Glob.cs
+++ b/NppNavigateTo/Glob.cs
@@ -105,6 +105,7 @@ namespace NavigateTo.Plugin.Namespace
                         sb.Append("\\\\");
                     break;
                 case '*':
+                    uses_metacharacters = true;
                     if (is_char_class)
                     {
                         sb.Append("\\*"); // "[*]" matches literal * character
@@ -114,7 +115,6 @@ namespace NavigateTo.Plugin.Namespace
                         break; // since globs are only anchored at the end,
                                // leading * in globs should not influence the matching behavior.
                                // For example, the globs "*foo.txt" and "foo.txt" should match the same things.
-                    uses_metacharacters = true;
                     next_c = Peek(inp);
                     if (next_c == '*')
                     {

--- a/NppNavigateTo/Tests/GlobTester.cs
+++ b/NppNavigateTo/Tests/GlobTester.cs
@@ -62,22 +62,22 @@ namespace NavigateTo.Tests
                     ("baz.txt", true),
                     ("foo.baz", true),
                 }),
-                ("foo**[!c-p]uack*.{tx?,cpp} !fgh | <bar baz", new[]
+                ("foo**[!c-p]u\\u0434ck*.{tx?,cpp} !fgh | <ba\\x72 baz", new[]
                 {
-                    ("foo\\boo\\quacked.txt", true),
-                    ("foo\\boo\\quacked.cpp", true),
-                    ("foozuack.txb", true),
+                    ("foo\\boo\\quдcked.txt", true),
+                    ("foo\\boo\\quдcked.cpp", true),
+                    ("foozuдck.txb", true),
                     ("bar.baz", true),
                     ("baz.bar", true),
                     ("fgh\\bar.baz", true),
-                    ("foo\\boo\\duacked.txt", false),
-                    ("foo\\boo\\uacked.txt", false),
-                    ("foozuack.xml", false),
+                    ("foo\\boo\\duдcked.txt", false),
+                    ("foo\\boo\\uдcked.txt", false),
+                    ("foozuдck.xml", false),
                     ("foo.baz", false),
-                    ("foo\\boo\\quacked.txto", false),
-                    ("foo\\fgh\\quacked.txt", false),
-                    ("foo\\fgh\\quacked.cpp", false),
-                    ("foo\\boo\\quacked\\bad.txt", false),
+                    ("foo\\boo\\quдcked.txto", false),
+                    ("foo\\fgh\\quдcked.txt", false),
+                    ("foo\\fgh\\quдcked.cpp", false),
+                    ("foo\\boo\\quдcked\\bad.txt", false),
                 }),
                 ("foo[ !]*.*", new[]
                 {

--- a/NppNavigateTo/Tests/GlobTester.cs
+++ b/NppNavigateTo/Tests/GlobTester.cs
@@ -160,6 +160,13 @@ namespace NavigateTo.Tests
                     ("aд.txt", false),
                     ("д.md", false),
                 }),
+                ("**.txt | *.json", new[]
+                {
+                    ("Z:\\foo.json", true),
+                    ("c:\\goon\\guk.txt", true),
+                    ("foo.jsonl", false),
+                    ("c:\\bar.txto", false),
+                }),
             };
             var glob = new Glob();
             foreach ((string query, var examples) in testcases)

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -15,6 +15,54 @@
 Examples:
 ![NavigateTo_With_Fuzzy](https://github.com/young-developer/nppNavigateTo/blob/master/documentation/Without_fuzzy.png)
 
+### Multi-glob syntax
+
+Multi-glob syntax lets the user search space-separated words or [globs](https://en.wikipedia.org/wiki/Glob_(programming)). __This syntax is case-insensitive.__ The rules are as follows:
+
+1. `foo bar txt` matches anything that contains the words `foo`, `bar`, and `txt`, for example `foobar.txt` *but not `bar.txt` or `foo.bar`*
+    * __Note that this is the same as the old behavior of NavigateTo before the introduction of glob syntax, so the old search behavior is retained.__
+2. `foo | bar` matches anything that contains *`foo` OR `bar`*, for example `foo.txt` and `bar.txt`
+3. `foo | <bar baz>` matches *`foo` OR (`bar` AND `baz`)*, like `foo.txt` and `bar.baz` but not `bar.txt`. That is, `<>` are grouping parentheses, although *`<` does not require a closing `>`*. 
+4. `foo !bar` matches *`foo` AND NOT `bar`*, that is, `!` before a search term represents logical negation. So `foo !bar` matches `foo.txt` but not `foo.bar` 
+5. `*.foo` uses *glob syntax* and matches anything that has the `.foo` extension.
+    * __Note that anything using the `*`, `[]`, and `{}` characters is considered a glob, and the end of the glob must match the end of the search target.__
+    * For example, while `foo` matches `foo.txt` or `txt.foo`, __`*.foo` matches `txt.foo` *but not `foo.txt`*__
+6. `*` matches any number of characters (including zero) *other than the path separator `\`.* Thus `r.c*` matches `bar.c` and `gor.cpp` *but not `jir.c\foo.bar`*
+7. `?` matches *any one character* other than the path separator `\`. Thus `foo.?` matches `foo.h` and `foo.c` but not `foo.cpzp` or `foo.h\bar.py`
+8. `[chars]` matches any one character inside the square brackets. It also matches *character ranges*, specifically `a-z`, `A-Z`, and `0-9` or any subset thereof.
+    * `*.a[0-2]` matches `foo.a0`, `foo.a1`, and `foo.a1`
+    * `*.[x-y1][7-8]` matches `foo.x7`, `foo.x8`, `foo.y7`, `foo.y8`, `foo.17`, and `foo.18`
+    * `big[ _]dog.txt` matches `big dog.txt` and `big_dog.txt`
+9. `[!chars]` matches *any one character __not__ inside the square brackets other than `\`.* Just as with `[chars]`, character groups can be negated.
+    *  `*.[!1-2]` matches `foo.a` and `foo.g` and `foo.3` *but not `foo.1` or `foo.2` or `foo.\bar.txt`*
+10. `\xNN` matches a unicode character at codepoint `NN`. For example, `\x21` matches the exclamation point `!`.
+    * `\xNN` escapes can be used in character classes. For example, `[\x61-\x6a]` matches the letters `a-z`.
+11. `\uNNNN` matches a unicode character at codepoint `NNNN`
+    * `\u0021` also matches `!`
+    * `\u0434` matches the Cyrillic character `д`
+    * `\uNNNN` escapes can be used in character classes. For example, `[\u03B1-\u03C9]` matches the lower-case Greek letters `α` through `ω`.
+12. `*.{foo,bar,baz}` matches `a.foo`, `a.bar`, and `a.baz`. That is, `{OPTION1,OPTION2,...,OPTIONN}` matches each comma-separated option within the `{}`
+    * You can use multiple `{}` alternations within the same glob. For example, `{foo,bar}.{txt,md}` matches `foo.txt`, `foo.md`, `bar.txt`, and `bar.md`
+
+#### Glob syntax "kitchen sink" example, `foo**[!c-p]u\u0434ck*.{tx?,cpp} !fgh | <ba\x72 baz`
+
+##### Matches
+1. `foo\boo\quдcked.txt` (recall that `\u0434` is `д`)
+2. `foo\boo\quдcked.cpp`
+3. `foozuдck.txb`
+4. `bar.baz` (note that `\x72` is `r`)
+5. `baz.bar`
+6. `fgh\bar.baz` (`fgh` is forbidden if the glob is being matched, but not if `bar baz` is being matched)
+
+##### Non-matches
+1. `foo\boo\duдcked.txt` (the `d` in `duдcked` is in the character class `c-p`, which was negated)
+2. `foozuдck.xml` (the `xml` extension does not match `tx?`)
+3. `foo.baz` (does not match the fancy glob, and it doesn't contain both `bar` and `baz`)
+4.  `foo\boo\quдcked.txto` (`txto` does not match `tx?` __because globs are always anchored at the end__ and `txto` has an `o` after the matching portion)
+7. `foo\fgh\quдcked.txt` (contains the forbidden search term `fgh`)
+8. `foo\boo\quдcked\bad.txt` (`uдck*` matches *any characters after* `uдck` *other than `\`*)
+
+
 ### Fuzzy Tabs Search
 Fuzzy search is based on: https://en.wikipedia.org/wiki/Longest_common_subsequence_problem
 Highlight is based on character.

--- a/test_results.txt
+++ b/test_results.txt
@@ -3,4 +3,4 @@ Test results for NavigateTo v2.6
 Testing Glob syntax
 =========================
 
-Ran 90 tests and failed 0
+Ran 94 tests and failed 0

--- a/test_results.txt
+++ b/test_results.txt
@@ -1,4 +1,4 @@
-Test results for NavigateTo v2.5.4
+Test results for NavigateTo v2.6
 =========================
 Testing Glob syntax
 =========================


### PR DESCRIPTION
Resolve [sub-issue of issue 50](https://github.com/young-developer/nppNavigateTo/issues/50#issuecomment-1627237880)

Also fix bug where leading `*` did not lead to globs being treated as globs.