### PR TITLE
Refresh search results on unhide, show open files on first load.

### DIFF
--- a/NppNavigateTo/Forms/FrmNavigateTo.cs
+++ b/NppNavigateTo/Forms/FrmNavigateTo.cs
@@ -103,6 +103,7 @@ namespace NavigateTo.Plugin.Namespace
             ReloadFileList();
             this.notepad.ReloadMenuItems();
             FormStyle.ApplyStyle(this, true, notepad.IsDarkModeEnabled());
+            FilterDataGrid("");
         }
 
         /// <summary>
@@ -617,11 +618,12 @@ namespace NavigateTo.Plugin.Namespace
         private void SearchComboBoxTextChanged(object sender, EventArgs e)
         {
             int textLength = searchComboBox.Text.Length;
+            bool emptyText = string.IsNullOrWhiteSpace(searchComboBox.Text);
             int minLength = FrmSettings.Settings.GetIntSetting(Settings.minTypeCharLimit);
 
-            if (textLength == 0)
+            if (emptyText)
                 ReloadFileList();
-            if (textLength > minLength)
+            if (textLength > minLength || emptyText)
             {
                 FilterDataGrid(searchComboBox.Text);
             }
@@ -884,6 +886,12 @@ namespace NavigateTo.Plugin.Namespace
             {
                 searchComboBox.Select(searchComboBox.Text.Length, 1);
             }
+        }
+
+        public void GrabFocus()
+        {
+            searchComboBox.Select();
+            FilterDataGrid(searchComboBox.Text);
         }
 
         private void dataGridFileList_KeyPress(object sender, KeyPressEventArgs e)

--- a/NppNavigateTo/Glob.cs
+++ b/NppNavigateTo/Glob.cs
@@ -197,7 +197,7 @@ namespace NavigateTo.Plugin.Namespace
                 ii++;
             }
             endOfLoop:
-            if (uses_metacharacters) // anything without "*" or "?" or "[]" or 
+            if (uses_metacharacters) // anything without any chars in "*?[]{}" will just be treated as a normal string
                 sb.Append('$'); // globs are anchored at the end; that is "*foo" does not match "foo/bar.txt" but "*foo.tx?" does
             string pat = sb.ToString();
             try

--- a/NppNavigateTo/NppNavigateTo.cs
+++ b/NppNavigateTo/NppNavigateTo.cs
@@ -204,6 +204,7 @@ namespace NavigateTo.Plugin.Namespace
                         frmNavigateTo.Handle);
                     Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_SETMENUITEMCHECK,
                         PluginBase._funcItems.Items[idFormNavigateAll]._cmdID, 1);
+                    frmNavigateTo.GrabFocus();
                 }
                 else
                 {
@@ -211,6 +212,7 @@ namespace NavigateTo.Plugin.Namespace
                         frmNavigateTo.Handle);
                     Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_SETMENUITEMCHECK,
                         PluginBase._funcItems.Items[idFormNavigateAll]._cmdID, 0);
+                    editor.GrabFocus();
                 }
             }
         }

--- a/NppNavigateTo/Tests/GlobTester.cs
+++ b/NppNavigateTo/Tests/GlobTester.cs
@@ -167,6 +167,17 @@ namespace NavigateTo.Tests
                     ("foo.jsonl", false),
                     ("c:\\bar.txto", false),
                 }),
+                ("*.p* !< __ | \\j", new[]
+                {
+                    ("bep.po", true),
+                    ("joo.po", true),
+                    ("boo\\joo.po", false),
+                    ("bbq.go", false),
+                    ("__bzz.po", false),
+                    ("boo\\j__.po", false),
+                    ("boo__\\eorpwn\\reiren.po", false),
+                    ("Z:\\jnq\\eorpwn\\reiren.po", false),
+                }),
             };
             var glob = new Glob();
             foreach ((string query, var examples) in testcases)

--- a/test_results.txt
+++ b/test_results.txt
@@ -3,4 +3,4 @@ Test results for NavigateTo v2.6
 Testing Glob syntax
 =========================
 
-Ran 94 tests and failed 0
+Ran 102 tests and failed 0


### PR DESCRIPTION
Problems that this commit should solve:
1. Hiding or showing the form changing input focus in an unclear way (fix issue #53)
2. Nothing showing when the form is first loaded (fix issue #36)
3. When the form is reloaded, it showed out-of-date search results (e.g., it would show files in the top directory of a file that is no longer active). There was no associated issue for this, but it bugged me.