### PR TITLE
add ctrl+backspace to delete word, performance optimizations

### DIFF
--- a/NppNavigateTo/FormStyle.cs
+++ b/NppNavigateTo/FormStyle.cs
@@ -3,6 +3,7 @@ using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using NppPluginNET;
 
 namespace NavigateTo.Plugin.Namespace
 {
@@ -25,8 +26,7 @@ namespace NavigateTo.Plugin.Namespace
         public static void ApplyStyle(Control ctrl, bool use_npp_style, bool isDark = false)
         {
             if (ctrl == null || ctrl.IsDisposed) return;
-            int[] version = Main.notepad.GetNppVersion();
-            if (version[0] < 8)
+            if (!MiscUtils.nppVersionAtLeast8)
                 use_npp_style = false; // trying to follow editor style looks weird for Notepad++ 7.3.3
             if (ctrl is Form form)
             {

--- a/NppNavigateTo/Forms/FrmSettings.cs
+++ b/NppNavigateTo/Forms/FrmSettings.cs
@@ -75,6 +75,7 @@ namespace NavigateTo.Plugin.Namespace
             comboBoxSortOrder.SelectedIndex = Settings.GetIntSetting(Settings.sortOrderAfterFilterBy);
             checkBoxFuzzySearch.Checked = Settings.GetBoolSetting(Settings.fuzzySearch);
             numericUpDownFuzzyness.Value = Settings.GetIntSetting(Settings.fuzzynessTolerance);
+            maxResultsHighlightingEnabledUpDown.Value = Settings.GetIntSetting(Settings.maxResultsHighlightingEnabled);
 
             DataGridViewRow newRow = new DataGridViewRow();
             newRow.CreateCells(dataGridFileListPreview);
@@ -164,6 +165,7 @@ namespace NavigateTo.Plugin.Namespace
             dataGridViewCellStyle1.BackColor = Settings.GetColorSetting(Settings.rowBackgroundColor);
             dataGridViewCellStyle1.SelectionBackColor = Settings.GetColorSetting(Settings.gridSelectedRowBackground);
             dataGridViewCellStyle1.SelectionForeColor = Settings.GetColorSetting(Settings.gridSelectedRowForeground);
+            // TODO: Add ability to change font
             dataGridFileListPreview.DefaultCellStyle = dataGridViewCellStyle1;
             dataGridFileListPreview.BackgroundColor = Settings.GetColorSetting(Settings.gridBackgroundColor);
             dataGridFileListPreview.BackColor = Settings.GetColorSetting(Settings.rowBackgroundColor);
@@ -263,6 +265,7 @@ namespace NavigateTo.Plugin.Namespace
             Settings.SetColorSetting(Settings.gridBackgroundColor, System.Drawing.SystemColors.AppWorkspace);
             Settings.SetColorSetting(Settings.highlightColorBackground, Color.Orange);
             Settings.SetColorSetting(Settings.rowBackgroundColor, Color.White);
+            //Settings.SetIntSetting(Settings.fontSize, 8); // Only once we figure out how to properly change font size
             RefreshDataGridStyles();
         }
 
@@ -349,6 +352,11 @@ namespace NavigateTo.Plugin.Namespace
         private void secondsBetweenDirectoryScans_ValueChanged(object sender, EventArgs e)
         {
             Settings.SetIntSetting(Settings.secondsBetweenDirectoryScans, (int)numUpDownSecsBetweenDirectoryScans.Value);
+        }
+
+        private void maxResultsHighlightingEnabled_ValueChanged(object sender, EventArgs e)
+        {
+            Settings.SetIntSetting(Settings.maxResultsHighlightingEnabled, (int)maxResultsHighlightingEnabledUpDown.Value);
         }
     }
 }

--- a/NppNavigateTo/Forms/FrmSettings.designer.cs
+++ b/NppNavigateTo/Forms/FrmSettings.designer.cs
@@ -51,6 +51,8 @@
             this.checkBoxFileNameResults = new System.Windows.Forms.CheckBox();
             this.checkBoxSearchMenu = new System.Windows.Forms.CheckBox();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.maxResultsHighlightingEnabledLabel = new System.Windows.Forms.Label();
+            this.maxResultsHighlightingEnabledUpDown = new System.Windows.Forms.NumericUpDown();
             this.buttonRowBackgroud = new System.Windows.Forms.Button();
             this.gridBackground = new System.Windows.Forms.Button();
             this.buttonResetStyle = new System.Windows.Forms.Button();
@@ -74,6 +76,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.numUpDownSecsBetweenDirectoryScans)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownFuzzyness)).BeginInit();
             this.groupBox4.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.maxResultsHighlightingEnabledUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridFileListPreview)).BeginInit();
             this.SuspendLayout();
             // 
@@ -330,9 +333,9 @@
             this.label7.AutoSize = true;
             this.label7.Location = new System.Drawing.Point(7, 77);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(241, 17);
+            this.label7.Size = new System.Drawing.Size(273, 17);
             this.label7.TabIndex = 12;
-            this.label7.Text = "Refresh file list how often? (seconds)";
+            this.label7.Text = "Re-search directory how often? (seconds)";
             // 
             // numericUpDownFuzzyness
             // 
@@ -391,6 +394,8 @@
             // 
             // groupBox4
             // 
+            this.groupBox4.Controls.Add(this.maxResultsHighlightingEnabledLabel);
+            this.groupBox4.Controls.Add(this.maxResultsHighlightingEnabledUpDown);
             this.groupBox4.Controls.Add(this.buttonRowBackgroud);
             this.groupBox4.Controls.Add(this.gridBackground);
             this.groupBox4.Controls.Add(this.buttonResetStyle);
@@ -404,14 +409,36 @@
             this.groupBox4.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.Padding = new System.Windows.Forms.Padding(4);
-            this.groupBox4.Size = new System.Drawing.Size(341, 184);
+            this.groupBox4.Size = new System.Drawing.Size(341, 213);
             this.groupBox4.TabIndex = 8;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Appearance";
             // 
+            // maxResultsHighlightingEnabledLabel
+            // 
+            this.maxResultsHighlightingEnabledLabel.AutoSize = true;
+            this.maxResultsHighlightingEnabledLabel.Location = new System.Drawing.Point(7, 179);
+            this.maxResultsHighlightingEnabledLabel.Name = "maxResultsHighlightingEnabledLabel";
+            this.maxResultsHighlightingEnabledLabel.Size = new System.Drawing.Size(251, 16);
+            this.maxResultsHighlightingEnabledLabel.TabIndex = 11;
+            this.maxResultsHighlightingEnabledLabel.Text = "Disable highlighting if >= this many results";
+            // 
+            // maxResultsHighlightingEnabledUpDown
+            // 
+            this.maxResultsHighlightingEnabledUpDown.Location = new System.Drawing.Point(266, 177);
+            this.maxResultsHighlightingEnabledUpDown.Maximum = new decimal(new int[] {
+            1000000,
+            0,
+            0,
+            0});
+            this.maxResultsHighlightingEnabledUpDown.Name = "maxResultsHighlightingEnabledUpDown";
+            this.maxResultsHighlightingEnabledUpDown.Size = new System.Drawing.Size(63, 22);
+            this.maxResultsHighlightingEnabledUpDown.TabIndex = 10;
+            this.maxResultsHighlightingEnabledUpDown.ValueChanged += new System.EventHandler(this.maxResultsHighlightingEnabled_ValueChanged);
+            // 
             // buttonRowBackgroud
             // 
-            this.buttonRowBackgroud.Location = new System.Drawing.Point(16, 135);
+            this.buttonRowBackgroud.Location = new System.Drawing.Point(11, 136);
             this.buttonRowBackgroud.Margin = new System.Windows.Forms.Padding(4);
             this.buttonRowBackgroud.Name = "buttonRowBackgroud";
             this.buttonRowBackgroud.Size = new System.Drawing.Size(152, 28);
@@ -422,7 +449,7 @@
             // 
             // gridBackground
             // 
-            this.gridBackground.Location = new System.Drawing.Point(16, 102);
+            this.gridBackground.Location = new System.Drawing.Point(11, 103);
             this.gridBackground.Margin = new System.Windows.Forms.Padding(4);
             this.gridBackground.Name = "gridBackground";
             this.gridBackground.Size = new System.Drawing.Size(152, 28);
@@ -433,7 +460,7 @@
             // 
             // buttonResetStyle
             // 
-            this.buttonResetStyle.Location = new System.Drawing.Point(271, 116);
+            this.buttonResetStyle.Location = new System.Drawing.Point(266, 117);
             this.buttonResetStyle.Margin = new System.Windows.Forms.Padding(4);
             this.buttonResetStyle.Name = "buttonResetStyle";
             this.buttonResetStyle.Size = new System.Drawing.Size(63, 28);
@@ -444,7 +471,7 @@
             // 
             // buttonSelectedRowText
             // 
-            this.buttonSelectedRowText.Location = new System.Drawing.Point(239, 65);
+            this.buttonSelectedRowText.Location = new System.Drawing.Point(234, 66);
             this.buttonSelectedRowText.Margin = new System.Windows.Forms.Padding(4);
             this.buttonSelectedRowText.Name = "buttonSelectedRowText";
             this.buttonSelectedRowText.Size = new System.Drawing.Size(53, 28);
@@ -455,7 +482,7 @@
             // 
             // buttonSelectedRowBack
             // 
-            this.buttonSelectedRowBack.Location = new System.Drawing.Point(132, 65);
+            this.buttonSelectedRowBack.Location = new System.Drawing.Point(127, 66);
             this.buttonSelectedRowBack.Margin = new System.Windows.Forms.Padding(4);
             this.buttonSelectedRowBack.Name = "buttonSelectedRowBack";
             this.buttonSelectedRowBack.Size = new System.Drawing.Size(99, 28);
@@ -467,7 +494,7 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(12, 71);
+            this.label4.Location = new System.Drawing.Point(7, 72);
             this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(91, 16);
@@ -477,7 +504,7 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(12, 30);
+            this.label3.Location = new System.Drawing.Point(7, 31);
             this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(59, 16);
@@ -486,7 +513,7 @@
             // 
             // buttonGridTextColor
             // 
-            this.buttonGridTextColor.Location = new System.Drawing.Point(239, 23);
+            this.buttonGridTextColor.Location = new System.Drawing.Point(234, 24);
             this.buttonGridTextColor.Margin = new System.Windows.Forms.Padding(4);
             this.buttonGridTextColor.Name = "buttonGridTextColor";
             this.buttonGridTextColor.Size = new System.Drawing.Size(53, 28);
@@ -497,7 +524,7 @@
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(132, 23);
+            this.button1.Location = new System.Drawing.Point(127, 24);
             this.button1.Margin = new System.Windows.Forms.Padding(4);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(99, 28);
@@ -530,7 +557,7 @@
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
             this.dataGridFileListPreview.DefaultCellStyle = dataGridViewCellStyle1;
-            this.dataGridFileListPreview.Location = new System.Drawing.Point(16, 378);
+            this.dataGridFileListPreview.Location = new System.Drawing.Point(16, 418);
             this.dataGridFileListPreview.Margin = new System.Windows.Forms.Padding(4);
             this.dataGridFileListPreview.Name = "dataGridFileListPreview";
             this.dataGridFileListPreview.ReadOnly = true;
@@ -573,7 +600,7 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(20, 353);
+            this.label2.Location = new System.Drawing.Point(20, 393);
             this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(58, 16);
@@ -584,7 +611,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(772, 583);
+            this.ClientSize = new System.Drawing.Size(772, 623);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.dataGridFileListPreview);
             this.Controls.Add(this.groupBox4);
@@ -610,6 +637,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownFuzzyness)).EndInit();
             this.groupBox4.ResumeLayout(false);
             this.groupBox4.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.maxResultsHighlightingEnabledUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridFileListPreview)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -654,5 +682,7 @@
         private System.Windows.Forms.Button buttonRowBackgroud;
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.NumericUpDown numUpDownSecsBetweenDirectoryScans;
+        private System.Windows.Forms.Label maxResultsHighlightingEnabledLabel;
+        private System.Windows.Forms.NumericUpDown maxResultsHighlightingEnabledUpDown;
     }
 }

--- a/NppNavigateTo/Forms/FrmSettings.resx
+++ b/NppNavigateTo/Forms/FrmSettings.resx
@@ -132,4 +132,7 @@
   <metadata name="$this.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>91</value>
+  </metadata>
 </root>

--- a/NppNavigateTo/MiscUtils.cs
+++ b/NppNavigateTo/MiscUtils.cs
@@ -21,6 +21,12 @@ namespace NppPluginNET
         /// </summary>
         public static INotepadPPGateway notepad = NavigateTo.Plugin.Namespace.Main.notepad;
 
+        public static readonly int[] nppVersion = notepad.GetNppVersion();
+
+        public static readonly string nppVersionStr = NppVersionString(true);
+
+        public static readonly bool nppVersionAtLeast8 = nppVersion[0] >= 8;
+
         /// <summary>
         /// append text to current doc, then append newline and move cursor
         /// </summary>
@@ -80,7 +86,17 @@ namespace NppPluginNET
             string version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
             while (version.EndsWith(".0"))
                 version = version.Substring(0, version.Length - 2);
+#if DEBUG
+            return $"{version} Debug";
+#else
             return version;
+#endif // DEBUG
+        }
+
+        private static string NppVersionString(bool include32bitVs64bit)
+        {
+            string nppVerStr = $"{nppVersion[0]}.{nppVersion[1]}.{nppVersion[2]}";
+            return include32bitVs64bit ? $"{nppVerStr} {IntPtr.Size * 8}bit" : nppVerStr;
         }
     }
 }

--- a/NppNavigateTo/Properties/AssemblyInfo.cs
+++ b/NppNavigateTo/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.6.4.0")]
-[assembly: AssemblyFileVersion("2.6.4.0")]
+[assembly: AssemblyVersion("2.6.5.0")]
+[assembly: AssemblyFileVersion("2.6.5.0")]

--- a/NppNavigateTo/Settings.cs
+++ b/NppNavigateTo/Settings.cs
@@ -23,6 +23,7 @@ namespace NppPluginNET
         public static string gridSelectedRowForeground = "gridSelectedRowForeground";
         public static string gridTextColor = "gridTextColor";
         public static string gridBackgroundColor = "gridBackgroundColor";
+        //public static string fontSize = "fontSize";
         public static string rowBackgroundColor = "rowBackgroundColor";
         public static string searchMenuCommands = "searchMenuCommands";
         public static string minTypeCharLimit = "minTypeCharLimit";
@@ -34,6 +35,7 @@ namespace NppPluginNET
         public static string fuzzySearch = "fuzzySearch";
         public static string fuzzynessTolerance = "fuzzynessTolerance";
         public static string secondsBetweenDirectoryScans = "secondsBetweenDirectoryScans";
+        public static string maxResultsHighlightingEnabled = "maxResultsHighlightingEnabled";
 
         static string iniFilePath;
         static string lpAppName = "NavigateTo";
@@ -147,7 +149,14 @@ namespace NppPluginNET
                 Win32.GetPrivateProfileInt(lpAppName, fuzzynessTolerance, 1, iniFilePath));
             LoadIntSetting(rowBackgroundColor,
                 Win32.GetPrivateProfileInt(lpAppName, rowBackgroundColor, -1, iniFilePath));
-            LoadIntSetting(secondsBetweenDirectoryScans, Win32.GetPrivateProfileInt(lpAppName, secondsBetweenDirectoryScans, 5, iniFilePath));
+            LoadIntSetting(secondsBetweenDirectoryScans,
+                Win32.GetPrivateProfileInt(lpAppName, secondsBetweenDirectoryScans, 5, iniFilePath));
+            LoadIntSetting(maxResultsHighlightingEnabled,
+                Win32.GetPrivateProfileInt(lpAppName, maxResultsHighlightingEnabled, 5000, iniFilePath));
+            // TODO: add customizable font size; changing font is tricky, so am not doing yet
+            //LoadIntSetting(fontSize,
+            //    Win32.GetPrivateProfileInt(lpAppName, fontSize, 8, iniFilePath));
+
         }
 
         public void SetColorSetting(String name, Color color)

--- a/NppNavigateTo/Tests/TestRunner.cs
+++ b/NppNavigateTo/Tests/TestRunner.cs
@@ -11,13 +11,19 @@ namespace NavigateTo.Tests
         public static void RunAll()
         {
             MiscUtils.notepad.FileNew();
-            MiscUtils.AddLine($"Test results for NavigateTo v{MiscUtils.AssemblyVersionString()}");
+            MiscUtils.AddLine($"Test results for NavigateTo v{MiscUtils.AssemblyVersionString()} on Notepad++ {MiscUtils.nppVersionStr}");
 
             MiscUtils.AddLine(@"=========================
 Testing Glob syntax
 =========================
 ");
             GlobTester.Test();
+
+            MiscUtils.AddLine(@"=========================
+Testing Glob syntax with cached top directories
+=========================
+");
+            GlobTester.TestCachedTopDirectory();
         }
     }
 }

--- a/test_results.txt
+++ b/test_results.txt
@@ -1,6 +1,11 @@
-Test results for NavigateTo v2.6
+Test results for NavigateTo v2.6.5 on Notepad++ 8.5.6 64bit
 =========================
 Testing Glob syntax
 =========================
 
 Ran 102 tests and failed 0
+=========================
+Testing Glob syntax with cached top directories
+=========================
+
+Ran 124 tests and failed 0


### PR DESCRIPTION
1. Ctrl+Backspace in the base form will now delete the word (sequence of non-whitespace, non-punctuation chars) ending at the cursor location (partially address #55 )
2. Added optimizations to reduce the frequency of updating of the file list.
3. Added the ability to disable highlighting of the file list if the number of results is large (for better performance, partially address #56)
4. Made directory search more efficient by "remembering" whether search terms matched the top directory and thus avoiding the cost of performing unnecessary regex matches.