### PR TITLE
Add keypress processing delay

### DIFF
--- a/NppNavigateTo/Properties/AssemblyInfo.cs
+++ b/NppNavigateTo/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.6.5.0")]
-[assembly: AssemblyFileVersion("2.6.5.0")]
+[assembly: AssemblyVersion("2.6.5.1")]
+[assembly: AssemblyFileVersion("2.6.5.1")]


### PR DESCRIPTION
Partially address issue #56.
Now the NavigateTo form waits a short time (currently 25ms) after each keypress before beginning processing. Any keypresses that happen during this interval are disregarded.
This can help avoid traps where every keypress causes a long delay.
Note that the form can still lock Notepad++ for long periods, but these lockups should be less frequent.

I am *fairly confident* that this PR should not lead to any changes to the textbox being ignored completely, but it may. If it does, reducing how long after the last keypress the timer.Elapsed callback must fire to not be ignored will probably help.

Also fixed minor regression created by my last PR where the user could not cause the form to go over the minimum character limit by using the space key alone.